### PR TITLE
Parsing from io.Reader + option to skip stop time validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,19 @@
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/public-transport/gtfsparser)](https://goreportcard.com/report/github.com/public-transport/gtfsparser) [![GoDoc](https://godoc.org/github.com/public-transport/gtfsparser?status.png)](https://godoc.org/github.com/public-transport/gtfsparser)
 
-A complete*, easy to use parsing library for GTFS data. Implemented in go. Accepts folders containing GTFS files and ZIPs. Feeds are validated during parsing. ID references are transformed into pointer references where appropriate.
+A complete*, easy to use parsing library for GTFS data. Implemented in go. Accepts folders containing GTFS files, ZIPs or io.Readers of zip files. Feeds are validated during parsing. ID references are transformed into pointer references where appropriate.
 
 This is a fork from the gtfsparser I developed at geOps, containing some minor improvements. Because of some changes to member types, this is _not_ a drop-in replacement for the geOps gtfsparser.
 
 ## Usage
 
+Normal usage:
     feed := gtfsparser.NewFeed()
     error := feed.Parse("sample-feed.zip")
+
+Reader usage:
+    feed := gtfsparser.NewFeed()
+    error := feed.ParseReader(reader)
 
 See feed.go for exported fields.
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,26 @@
-[![Go Report Card](https://goreportcard.com/badge/github.com/public-transport/gtfsparser)](https://goreportcard.com/report/github.com/public-transport/gtfsparser) [![GoDoc](https://godoc.org/github.com/public-transport/gtfsparser?status.png)](https://godoc.org/github.com/public-transport/gtfsparser)
-
 # go gtfsparser
+
+[![Go Report Card](https://goreportcard.com/badge/github.com/public-transport/gtfsparser)](https://goreportcard.com/report/github.com/public-transport/gtfsparser) [![GoDoc](https://godoc.org/github.com/public-transport/gtfsparser?status.png)](https://godoc.org/github.com/public-transport/gtfsparser)
 
 A complete*, easy to use parsing library for GTFS data. Implemented in go. Accepts folders containing GTFS files and ZIPs. Feeds are validated during parsing. ID references are transformed into pointer references where appropriate.
 
 This is a fork from the gtfsparser I developed at geOps, containing some minor improvements. Because of some changes to member types, this is _not_ a drop-in replacement for the geOps gtfsparser.
 
 ## Usage
+
     feed := gtfsparser.NewFeed()
     error := feed.Parse("sample-feed.zip")
-    
+
 See feed.go for exported fields.
 
-## Example
+### Example
 
 Parsing of the [GTFS example feed](https://developers.google.com/transit/gtfs/examples/gtfs-feed):
-    
+
 ```go
 import (
-	"github.com/public-transport/gtfsparser"
-	"fmt"
+    "github.com/Leocraft1/gtfsparser-with-reader"
+    "fmt"
 )
 
 func main() {
@@ -36,7 +37,8 @@ func main() {
 ```
 
 #### Output
-```
+
+```bash
 Done, parsed 1 agencies, 9 stops, 5 routes, 11 trips, 2 fare attributes
 
 [BULLFROG] Bullfrog (Demo) (@ 36.881081,-116.817970)

--- a/csvparser.go
+++ b/csvparser.go
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a GPL v2
 // license that can be found in the LICENSE file
 
-package gtfsparser
+package gtfsparserwr
 
 import (
 	"bufio"

--- a/feed.go
+++ b/feed.go
@@ -193,7 +193,7 @@ type Feed struct {
 
 	fastParsePossible bool
 
-	opts ParseOptions
+	Opts ParseOptions
 }
 
 // NewFeed creates a new, empty feed
@@ -230,7 +230,7 @@ func NewFeed() *Feed {
 		NumShpPoints:          0,
 		NumStopTimes:          0,
 		fastParsePossible:     true,
-		opts:                  ParseOptions{false, false, false, false, false, "", "", false, false, false, false, gtfs.Date{}, gtfs.Date{}, make([]Polygon, 0), false, make(map[int16]bool, 0), make(map[int16]bool, 0), false, false, false, false},
+		Opts:                  ParseOptions{false, false, false, false, false, "", "", false, false, false, false, gtfs.Date{}, gtfs.Date{}, make([]Polygon, 0), false, make(map[int16]bool, 0), make(map[int16]bool, 0), false, false, false, false},
 	}
 	g.lastString = &g.emptyString
 
@@ -239,7 +239,7 @@ func NewFeed() *Feed {
 
 // SetParseOpts sets the ParseOptions for this feed
 func (feed *Feed) SetParseOpts(opts ParseOptions) {
-	feed.opts = opts
+	feed.Opts = opts
 }
 
 // Parse the GTFS data in the specified folder into the feed
@@ -267,7 +267,7 @@ func (feed *Feed) PrefixParse(path string, prefix string) error {
 	// with -De
 	filteredTrips := make(map[string]struct{}, 0)
 
-	e = feed.parseAgencies(path, prefix, feed.opts.EmptyAgencyUrlRepl)
+	e = feed.parseAgencies(path, prefix, feed.Opts.EmptyAgencyUrlRepl)
 	if e == nil {
 		e = feed.parseFeedInfos(path)
 	}
@@ -335,7 +335,7 @@ func (feed *Feed) PrefixParse(path string, prefix string) error {
 	// }
 
 	//At this point, all possible GTFS is parsed, if there are extra files, it puts them under AdditionalFiles or AdditionalCsvFiles
-	if e == nil && feed.opts.KeepAddFlds {
+	if e == nil && feed.Opts.KeepAddFlds {
 		var files []string
 		files, e = feed.listFiles(path)
 		for _, file := range files {
@@ -350,7 +350,7 @@ func (feed *Feed) PrefixParse(path string, prefix string) error {
 
 			// assume that .txt means CSV
 			if strings.HasSuffix(file, ".txt") {
-				reader := NewCsvParser(r, feed.opts.DropErroneous, false)
+				reader := NewCsvParser(r, feed.Opts.DropErroneous, false)
 				var csv CsvFile
 				csv.Header = reader.GetHeader()
 				for record := reader.ParseCsvLine(); record != nil; record = reader.ParseCsvLine() {
@@ -376,11 +376,11 @@ func (feed *Feed) PrefixParse(path string, prefix string) error {
 		feed.curFileHandle = nil
 	}
 
-	if !feed.opts.DateFilterStart.IsEmpty() || !feed.opts.DateFilterEnd.IsEmpty() {
+	if !feed.Opts.DateFilterStart.IsEmpty() || !feed.Opts.DateFilterEnd.IsEmpty() {
 		feed.filterServices()
 	}
 
-	if feed.opts.DropSingleStopTrips {
+	if feed.Opts.DropSingleStopTrips {
 		for _, t := range feed.Trips {
 			if len(t.StopTimes) < 2 {
 				feed.DeleteTrip(t.Id)
@@ -435,7 +435,7 @@ func (feed *Feed) getFile(path string, name string) (io.Reader, error) {
 	// check for any directory that is a ZIP file
 	zipDir := feed.getGTFSDir()
 
-	if !feed.opts.ZipFix {
+	if !feed.Opts.ZipFix {
 		zipDir = ""
 	}
 
@@ -482,7 +482,7 @@ func (feed *Feed) listFiles(path string) ([]string, error) {
 	// check for any directory that is a ZIP file
 	zipDir := feed.getGTFSDir()
 
-	if !feed.opts.ZipFix {
+	if !feed.Opts.ZipFix {
 		zipDir = ""
 	}
 
@@ -503,7 +503,7 @@ func (feed *Feed) parseAgencies(path string, prefix string, fallbackUrl string) 
 		return errors.New("could not open required file agency.txt")
 	}
 
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -525,7 +525,7 @@ func (feed *Feed) parseAgencies(path string, prefix string, fallbackUrl string) 
 
 	addFlds := make([]int, 0)
 
-	if feed.opts.KeepAddFlds {
+	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
 	for record = reader.ParseCsvLine(); record != nil; record = reader.ParseCsvLine() {
@@ -550,7 +550,7 @@ func (feed *Feed) parseAgencies(path string, prefix string, fallbackUrl string) 
 		}
 
 		if e != nil {
-			if feed.opts.DropErroneous {
+			if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedAgencies++
 				feed.warn(e)
 				continue
@@ -592,7 +592,7 @@ func (feed *Feed) parseStops(path string, prefix string, geofiltered map[string]
 		return errors.New("could not open required file stops.txt")
 	}
 
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -620,7 +620,7 @@ func (feed *Feed) parseStops(path string, prefix string, geofiltered map[string]
 
 	addFlds := make([]int, 0)
 
-	if feed.opts.KeepAddFlds {
+	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
 
@@ -633,7 +633,7 @@ func (feed *Feed) parseStops(path string, prefix string, geofiltered map[string]
 			}
 		}
 		if e != nil {
-			if feed.opts.DropErroneous {
+			if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedStops++
 				feed.warn(e)
 				continue
@@ -644,7 +644,7 @@ func (feed *Feed) parseStops(path string, prefix string, geofiltered map[string]
 
 		// check if any defined PolygonFilter contains the stop
 		contains := true
-		for _, poly := range feed.opts.PolygonFilter {
+		for _, poly := range feed.Opts.PolygonFilter {
 			contains = false
 			if poly.PolyContains(float64(stop.Lon), float64(stop.Lat)) {
 				contains = true
@@ -687,11 +687,11 @@ func (feed *Feed) parseStops(path string, prefix string, geofiltered map[string]
 			if wasFiltered && feed.Stops[id].Location_type < 2 {
 				// continue, the default value "nil" has already be written above
 				continue
-			} else if feed.opts.UseDefValueOnError && feed.Stops[id].Location_type < 2 {
+			} else if feed.Opts.UseDefValueOnError && feed.Stops[id].Location_type < 2 {
 				// continue, the default value "nil" has already be written above
 				feed.warn(locErr)
 				continue
-			} else if feed.opts.DropErroneous {
+			} else if feed.Opts.DropErroneous {
 				// delete the erroneous entry
 				delete(feed.Stops, id)
 				feed.ErrorStats.DroppedStops++
@@ -704,11 +704,11 @@ func (feed *Feed) parseStops(path string, prefix string, geofiltered map[string]
 
 		if (feed.Stops[id].Location_type == 0 || feed.Stops[id].Location_type == 2 || feed.Stops[id].Location_type == 3) && pstop.Location_type != 1 {
 			locErr := fmt.Errorf("(for stop id %s) Station with id %s has location_type=%d, cannot use as parent station here for stop with location_type=%d (must be 1)", id, pid, pstop.Location_type, feed.Stops[id].Location_type)
-			if feed.opts.UseDefValueOnError && !(feed.Stops[id].Location_type == 2 || feed.Stops[id].Location_type == 3) {
+			if feed.Opts.UseDefValueOnError && !(feed.Stops[id].Location_type == 2 || feed.Stops[id].Location_type == 3) {
 				// continue, the default value "nil" has already be written above
 				feed.warn(locErr)
 				continue
-			} else if feed.opts.DropErroneous {
+			} else if feed.Opts.DropErroneous {
 				// delete the erroneous entry
 				delete(feed.Stops, id)
 				feed.ErrorStats.DroppedStops++
@@ -721,7 +721,7 @@ func (feed *Feed) parseStops(path string, prefix string, geofiltered map[string]
 
 		if feed.Stops[id].Location_type == 4 && pstop.Location_type != 0 {
 			locErr := fmt.Errorf("(for stop id %s) Station with id %s has location_type=%d, cannot use as parent station here for stop with location_type=4 (boarding area), which expects a parent station with location_type=0 (stop/platform)", id, pid, pstop.Location_type)
-			if feed.opts.DropErroneous {
+			if feed.Opts.DropErroneous {
 				// delete the erroneous entry
 				delete(feed.Stops, id)
 				feed.ErrorStats.DroppedStops++
@@ -745,7 +745,7 @@ func (feed *Feed) parseRoutes(path string, prefix string, filtered map[string]st
 		return errors.New("could not open required file routes.txt")
 	}
 
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -771,7 +771,7 @@ func (feed *Feed) parseRoutes(path string, prefix string, filtered map[string]st
 
 	addFlds := make([]int, 0)
 
-	if feed.opts.KeepAddFlds {
+	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
 
@@ -783,7 +783,7 @@ func (feed *Feed) parseRoutes(path string, prefix string, filtered map[string]st
 			}
 		}
 		if e != nil {
-			if feed.opts.DropErroneous {
+			if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedRoutes++
 				feed.warn(e)
 				continue
@@ -792,29 +792,29 @@ func (feed *Feed) parseRoutes(path string, prefix string, filtered map[string]st
 			}
 		}
 
-		if feed.opts.UseStandardRouteTypes {
+		if feed.Opts.UseStandardRouteTypes {
 			route.Type = gtfs.GetTypeFromExtended(route.Type)
 		}
 
-		if feed.opts.UseGoogleSupportedRouteTypes {
+		if feed.Opts.UseGoogleSupportedRouteTypes {
 			route.Type = gtfs.GetSupportedExtendedTypeFromExtended(route.Type)
 		}
 
-		if len(feed.opts.MOTFilter) != 0 {
-			if _, ok := feed.opts.MOTFilter[route.Type]; !ok {
+		if len(feed.Opts.MOTFilter) != 0 {
+			if _, ok := feed.Opts.MOTFilter[route.Type]; !ok {
 				filtered[route.Id] = struct{}{}
 				continue
 			}
 		}
 
-		if len(feed.opts.MOTFilterNeg) != 0 {
-			if _, ok := feed.opts.MOTFilterNeg[route.Type]; ok {
+		if len(feed.Opts.MOTFilterNeg) != 0 {
+			if _, ok := feed.Opts.MOTFilterNeg[route.Type]; ok {
 				filtered[route.Id] = struct{}{}
 				continue
 			}
 		}
 
-		if feed.opts.DryRun {
+		if feed.Opts.DryRun {
 			feed.Routes[route.Id] = route
 		} else {
 			feed.Routes[route.Id] = route
@@ -843,8 +843,8 @@ func (feed *Feed) parseCalendar(path string, prefix string) (err error) {
 		return nil
 	}
 
-	// reader := NewCsvParser(file, feed.opts.DropErroneous, feed.opts.AssumeCleanCsv && !feed.opts.KeepAddFlds)
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	// reader := NewCsvParser(file, feed.Opts.DropErroneous, feed.Opts.AssumeCleanCsv && !feed.Opts.KeepAddFlds)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -870,7 +870,7 @@ func (feed *Feed) parseCalendar(path string, prefix string) (err error) {
 		service, e := createServiceFromCalendar(record, flds, feed, prefix)
 
 		if e != nil {
-			if feed.opts.DropErroneous {
+			if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedServices++
 				feed.warn(e)
 				continue
@@ -881,26 +881,26 @@ func (feed *Feed) parseCalendar(path string, prefix string) (err error) {
 
 		// if service was parsed in-place, nil was returned
 		if service != nil {
-			if feed.opts.DryRun {
+			if feed.Opts.DryRun {
 				feed.Services[service.Id()] = nil
 			} else {
 				feed.Services[service.Id()] = service
 
 				// check if service is completely out of range
-				if !feed.opts.DateFilterStart.IsEmpty() && service.End_date().GetTime().Before(feed.opts.DateFilterStart.GetTime()) || !feed.opts.DateFilterEnd.IsEmpty() && service.Start_date().GetTime().After(feed.opts.DateFilterEnd.GetTime()) {
+				if !feed.Opts.DateFilterStart.IsEmpty() && service.End_date().GetTime().Before(feed.Opts.DateFilterStart.GetTime()) || !feed.Opts.DateFilterEnd.IsEmpty() && service.Start_date().GetTime().After(feed.Opts.DateFilterEnd.GetTime()) {
 					service.SetRawDaymap(0)
 				} else {
 					// we overlap, there are now two cases:
 
 					// 1. A start date is defined, and the service starts before the start time. Set the start time to the new start time
-					if !feed.opts.DateFilterStart.IsEmpty() && service.Start_date().GetTime().Before(feed.opts.DateFilterStart.GetTime()) {
-						service.SetStart_date(feed.opts.DateFilterStart)
+					if !feed.Opts.DateFilterStart.IsEmpty() && service.Start_date().GetTime().Before(feed.Opts.DateFilterStart.GetTime()) {
+						service.SetStart_date(feed.Opts.DateFilterStart)
 						// note: because of the check above, End_date is guaranteed to >= DateFilterStart, so our service remains valid
 					}
 
 					// 2. An end date is defined, and the service ends after the start time. Set the end  time to the new end time
-					if !feed.opts.DateFilterEnd.IsEmpty() && service.End_date().GetTime().After(feed.opts.DateFilterEnd.GetTime()) {
-						service.SetEnd_date(feed.opts.DateFilterEnd)
+					if !feed.Opts.DateFilterEnd.IsEmpty() && service.End_date().GetTime().After(feed.Opts.DateFilterEnd.GetTime()) {
+						service.SetEnd_date(feed.Opts.DateFilterEnd)
 						// note: because of the check above, Start_date is guaranteed to <= DateFilterEnd, so our service remains valid
 					}
 				}
@@ -920,8 +920,8 @@ func (feed *Feed) parseCalendarDates(path string, prefix string) (err error) {
 		return nil
 	}
 
-	// reader := NewCsvParser(file, feed.opts.DropErroneous, feed.opts.AssumeCleanCsv && !feed.opts.KeepAddFlds)
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	// reader := NewCsvParser(file, feed.Opts.DropErroneous, feed.Opts.AssumeCleanCsv && !feed.Opts.KeepAddFlds)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -937,10 +937,10 @@ func (feed *Feed) parseCalendarDates(path string, prefix string) (err error) {
 	}
 
 	for record = reader.ParseCsvLine(); record != nil; record = reader.ParseCsvLine() {
-		service, e := createServiceFromCalendarDates(record, flds, feed, feed.opts.DateFilterStart, feed.opts.DateFilterEnd, prefix)
+		service, e := createServiceFromCalendarDates(record, flds, feed, feed.Opts.DateFilterStart, feed.Opts.DateFilterEnd, prefix)
 
 		if e != nil {
-			if feed.opts.DropErroneous {
+			if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedServices++
 				feed.warn(e)
 				continue
@@ -951,7 +951,7 @@ func (feed *Feed) parseCalendarDates(path string, prefix string) (err error) {
 
 		// if service was parsed in-place, nil was returned
 		if service != nil {
-			if feed.opts.DryRun {
+			if feed.Opts.DryRun {
 				feed.Services[service.Id()] = nil
 			} else {
 				feed.Services[service.Id()] = service
@@ -971,7 +971,7 @@ func (feed *Feed) parseTrips(path string, prefix string, filteredRoutes map[stri
 		return errors.New("could not open required file trips.txt")
 	}
 
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -995,7 +995,7 @@ func (feed *Feed) parseTrips(path string, prefix string, filteredRoutes map[stri
 
 	addFlds := make([]int, 0)
 
-	if feed.opts.KeepAddFlds {
+	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
 
@@ -1023,7 +1023,7 @@ func (feed *Feed) parseTrips(path string, prefix string, filteredRoutes map[stri
 			if wasFiltered {
 				filteredTrips[routeNotFoundErr.PayloadId()] = struct{}{}
 				continue
-			} else if feed.opts.DropErroneous {
+			} else if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedTrips++
 				feed.warn(e)
 				continue
@@ -1050,7 +1050,7 @@ func (feed *Feed) parseTrips(path string, prefix string, filteredRoutes map[stri
 }
 
 func (feed *Feed) reserveShapes(path string, prefix string) (err error) {
-	if feed.opts.DropShapes {
+	if feed.Opts.DropShapes {
 		return
 	}
 	file, e := feed.getFile(path, "shapes.txt")
@@ -1059,7 +1059,7 @@ func (feed *Feed) reserveShapes(path string, prefix string) (err error) {
 		return nil
 	}
 
-	reader := NewCsvParser(file, feed.opts.DropErroneous, feed.opts.AssumeCleanCsv && !feed.opts.KeepAddFlds)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, feed.Opts.AssumeCleanCsv && !feed.Opts.KeepAddFlds)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -1079,7 +1079,7 @@ func (feed *Feed) reserveShapes(path string, prefix string) (err error) {
 	for record = reader.ParseCsvLine(); record != nil; record = reader.ParseCsvLine() {
 		e := reserveShapePoint(record, flds, feed, prefix)
 		if e != nil {
-			if feed.opts.DropErroneous {
+			if feed.Opts.DropErroneous {
 				continue
 			} else {
 				panic(e)
@@ -1091,7 +1091,7 @@ func (feed *Feed) reserveShapes(path string, prefix string) (err error) {
 }
 
 func (feed *Feed) parseShapes(path string, prefix string) (err error) {
-	if feed.opts.DropShapes {
+	if feed.Opts.DropShapes {
 		return
 	}
 	file, e := feed.getFile(path, "shapes.txt")
@@ -1100,7 +1100,7 @@ func (feed *Feed) parseShapes(path string, prefix string) (err error) {
 		return nil
 	}
 
-	reader := NewCsvParser(file, feed.opts.DropErroneous, feed.opts.AssumeCleanCsv && !feed.opts.KeepAddFlds)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, feed.Opts.AssumeCleanCsv && !feed.Opts.KeepAddFlds)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -1119,7 +1119,7 @@ func (feed *Feed) parseShapes(path string, prefix string) (err error) {
 
 	addFlds := make([]int, 0)
 
-	if feed.opts.KeepAddFlds {
+	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
 
@@ -1131,7 +1131,7 @@ func (feed *Feed) parseShapes(path string, prefix string) (err error) {
 		shape, sp, e := createShapePoint(record, flds, feed, prefix)
 
 		if e != nil {
-			if feed.opts.DropErroneous {
+			if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedShapes++
 				feed.warn(e)
 				continue
@@ -1161,7 +1161,7 @@ func (feed *Feed) parseShapes(path string, prefix string) (err error) {
 		for id, shape := range feed.Shapes {
 			if len(shape.Points) == 0 {
 				loce := fmt.Errorf("shape #%s has no points", id)
-				if feed.opts.DropErroneous || len(feed.opts.PolygonFilter) > 0 {
+				if feed.Opts.DropErroneous || len(feed.Opts.PolygonFilter) > 0 {
 					// dont warn here, because this can only happen if a shape point
 					// has been deleted before
 					delete(feed.Shapes, id)
@@ -1171,13 +1171,13 @@ func (feed *Feed) parseShapes(path string, prefix string) (err error) {
 				}
 			}
 			sort.Sort(shape.Points)
-			e = feed.checkShapeMeasure(shape, &feed.opts)
+			e = feed.checkShapeMeasure(shape, &feed.Opts)
 			feed.NumShpPoints += len(shape.Points)
 			if e != nil {
 				break
 			}
 		}
-		if feed.opts.DryRun {
+		if feed.Opts.DryRun {
 			// clear space
 			for id := range feed.Shapes {
 				feed.Shapes[id] = nil
@@ -1194,7 +1194,7 @@ func (feed *Feed) reserveStopTimes(path string, prefix string) (err error) {
 	if e != nil {
 		return errors.New("could not open required file stop_times.txt")
 	}
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -1224,7 +1224,7 @@ func (feed *Feed) reserveStopTimes(path string, prefix string) (err error) {
 		return errors.New("could not open required file stop_times.txt")
 	}
 
-	reader = NewCsvParser(file, feed.opts.DropErroneous, feed.opts.AssumeCleanCsv && flds.stopHeadsign < 0 && !feed.opts.KeepAddFlds)
+	reader = NewCsvParser(file, feed.Opts.DropErroneous, feed.Opts.AssumeCleanCsv && flds.stopHeadsign < 0 && !feed.Opts.KeepAddFlds)
 
 	for record = reader.ParseCsvLine(); record != nil; record = reader.ParseCsvLine() {
 		reserveStopTime(record, flds, feed, prefix)
@@ -1239,7 +1239,7 @@ func (feed *Feed) parseStopTimes(path string, prefix string, geofiltered map[str
 	if e != nil {
 		return errors.New("could not open required file stop_times.txt")
 	}
-	reader := NewCsvParser(file, feed.opts.DropErroneous, feed.opts.AssumeCleanCsv && !feed.opts.KeepAddFlds)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, feed.Opts.AssumeCleanCsv && !feed.Opts.KeepAddFlds)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -1265,7 +1265,7 @@ func (feed *Feed) parseStopTimes(path string, prefix string, geofiltered map[str
 
 	addFlds := make([]int, 0)
 
-	if feed.opts.KeepAddFlds {
+	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
 
@@ -1275,7 +1275,7 @@ func (feed *Feed) parseStopTimes(path string, prefix string, geofiltered map[str
 		return errors.New("could not open required file stop_times.txt")
 	}
 
-	reader = NewCsvParser(file, feed.opts.DropErroneous, feed.opts.AssumeCleanCsv && flds.stopHeadsign < 0)
+	reader = NewCsvParser(file, feed.Opts.DropErroneous, feed.Opts.AssumeCleanCsv && flds.stopHeadsign < 0)
 
 	i := 0
 
@@ -1298,7 +1298,7 @@ func (feed *Feed) parseStopTimes(path string, prefix string, geofiltered map[str
 
 			if wasFiltered {
 				continue
-			} else if feed.opts.DropErroneous {
+			} else if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedStopTimes++
 				feed.warn(e)
 				continue
@@ -1327,7 +1327,7 @@ func (feed *Feed) parseStopTimes(path string, prefix string, geofiltered map[str
 		// sort stoptimes in trips
 		for _, trip := range feed.Trips {
 			sort.Sort(trip.StopTimes)
-			e = feed.checkStopTimeMeasure(trip, &feed.opts)
+			e = feed.checkStopTimeMeasure(trip, &feed.Opts)
 			feed.NumStopTimes += len(trip.StopTimes)
 			if e != nil {
 				break
@@ -1344,7 +1344,7 @@ func (feed *Feed) parseFrequencies(path string, prefix string, filteredTrips map
 	if e != nil {
 		return nil
 	}
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -1363,7 +1363,7 @@ func (feed *Feed) parseFrequencies(path string, prefix string, filteredTrips map
 
 	addFlds := make([]int, 0)
 
-	if feed.opts.KeepAddFlds {
+	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
 
@@ -1378,7 +1378,7 @@ func (feed *Feed) parseFrequencies(path string, prefix string, filteredTrips map
 
 			if wasFiltered {
 				continue
-			} else if feed.opts.DropErroneous {
+			} else if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedFrequencies++
 				feed.warn(e)
 				continue
@@ -1412,7 +1412,7 @@ func (feed *Feed) parseFareAttributes(path string, prefix string) (err error) {
 	if e != nil {
 		return nil
 	}
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -1433,14 +1433,14 @@ func (feed *Feed) parseFareAttributes(path string, prefix string) (err error) {
 
 	addFlds := make([]int, 0)
 
-	if feed.opts.KeepAddFlds {
+	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
 
 	for record = reader.ParseCsvLine(); record != nil; record = reader.ParseCsvLine() {
 		fa, e := createFareAttribute(record, flds, feed, prefix)
 		if e != nil {
-			if feed.opts.DropErroneous {
+			if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedFareAttributes++
 				feed.warn(e)
 				continue
@@ -1472,7 +1472,7 @@ func (feed *Feed) parseFareAttributeRules(path string, prefix string, filteredRo
 	if e != nil {
 		return nil
 	}
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -1491,7 +1491,7 @@ func (feed *Feed) parseFareAttributeRules(path string, prefix string, filteredRo
 
 	addFlds := make([]int, 0)
 
-	if feed.opts.KeepAddFlds {
+	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
 
@@ -1506,7 +1506,7 @@ func (feed *Feed) parseFareAttributeRules(path string, prefix string, filteredRo
 
 			if wasFiltered {
 				continue
-			} else if feed.opts.DropErroneous {
+			} else if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedFareAttributeRules++
 				feed.warn(e)
 				continue
@@ -1541,7 +1541,7 @@ func (feed *Feed) parseTransfers(path string, prefix string, geofiltered map[str
 	if e != nil {
 		return nil
 	}
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -1563,7 +1563,7 @@ func (feed *Feed) parseTransfers(path string, prefix string, geofiltered map[str
 
 	addFlds := make([]int, 0)
 
-	if feed.opts.KeepAddFlds {
+	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
 	for record = reader.ParseCsvLine(); record != nil; record = reader.ParseCsvLine() {
@@ -1582,7 +1582,7 @@ func (feed *Feed) parseTransfers(path string, prefix string, geofiltered map[str
 
 			if wasFiltered {
 				continue
-			} else if feed.opts.DropErroneous {
+			} else if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedTransfers++
 				feed.warn(e)
 				continue
@@ -1593,7 +1593,7 @@ func (feed *Feed) parseTransfers(path string, prefix string, geofiltered map[str
 
 		feed.Transfers[tk] = tv
 
-		if !feed.opts.DryRun {
+		if !feed.Opts.DryRun {
 			// add additional CSV fields
 			for _, i := range addFlds {
 				if i < len(record) {
@@ -1618,7 +1618,7 @@ func (feed *Feed) parsePathways(path string, prefix string, geofiltered map[stri
 	if e != nil {
 		return nil
 	}
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -1644,7 +1644,7 @@ func (feed *Feed) parsePathways(path string, prefix string, geofiltered map[stri
 
 	addFlds := make([]int, 0)
 
-	if feed.opts.KeepAddFlds {
+	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
 
@@ -1664,7 +1664,7 @@ func (feed *Feed) parsePathways(path string, prefix string, geofiltered map[stri
 
 			if wasFiltered {
 				continue
-			} else if feed.opts.DropErroneous {
+			} else if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedPathways++
 				feed.warn(e)
 				continue
@@ -1696,7 +1696,7 @@ func (feed *Feed) parseTranslations(path string, prefix string) (err error) {
 	if e != nil {
 		return nil
 	}
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -1717,14 +1717,14 @@ func (feed *Feed) parseTranslations(path string, prefix string) (err error) {
 
 	addFlds := make([]int, 0)
 
-	if feed.opts.KeepAddFlds {
+	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
 
 	for record = reader.ParseCsvLine(); record != nil; record = reader.ParseCsvLine() {
 		trans, e := createTranslation(record, flds, feed, prefix)
 		if e != nil {
-			if feed.opts.DropErroneous {
+			if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedTranslations++
 				feed.warn(e)
 				continue
@@ -1757,7 +1757,7 @@ func (feed *Feed) parseAttributions(path string, prefix string, filteredRoutes m
 	if e != nil {
 		return nil
 	}
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -1784,7 +1784,7 @@ func (feed *Feed) parseAttributions(path string, prefix string, filteredRoutes m
 
 	addFlds := make([]int, 0)
 
-	if feed.opts.KeepAddFlds {
+	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
 
@@ -1816,7 +1816,7 @@ func (feed *Feed) parseAttributions(path string, prefix string, filteredRoutes m
 
 			if wasFiltered {
 				continue
-			} else if feed.opts.DropErroneous {
+			} else if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedAttributions++
 				feed.warn(e)
 				continue
@@ -1863,7 +1863,7 @@ func (feed *Feed) parseLevels(path string, idprefix string) (err error) {
 	if e != nil {
 		return nil
 	}
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -1880,7 +1880,7 @@ func (feed *Feed) parseLevels(path string, idprefix string) (err error) {
 
 	addFlds := make([]int, 0)
 
-	if feed.opts.KeepAddFlds {
+	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
 	for record = reader.ParseCsvLine(); record != nil; record = reader.ParseCsvLine() {
@@ -1892,7 +1892,7 @@ func (feed *Feed) parseLevels(path string, idprefix string) (err error) {
 		}
 
 		if e != nil {
-			if feed.opts.DropErroneous {
+			if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedLevels++
 				feed.warn(e)
 				continue
@@ -1924,7 +1924,7 @@ func (feed *Feed) parseFeedInfos(path string) (err error) {
 	if e != nil {
 		return nil
 	}
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -1946,14 +1946,14 @@ func (feed *Feed) parseFeedInfos(path string) (err error) {
 
 	addFlds := make([]int, 0)
 
-	if feed.opts.KeepAddFlds {
+	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
 
 	for record = reader.ParseCsvLine(); record != nil; record = reader.ParseCsvLine() {
 		fi, e := createFeedInfo(record, flds, feed)
 		if e != nil {
-			if feed.opts.DropErroneous {
+			if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedFeedInfos++
 				feed.warn(e)
 				continue
@@ -1961,7 +1961,7 @@ func (feed *Feed) parseFeedInfos(path string) (err error) {
 				panic(e)
 			}
 		}
-		if !feed.opts.DryRun {
+		if !feed.Opts.DryRun {
 			for _, i := range addFlds {
 				if i < len(record) {
 					if _, ok := feed.FeedInfosAddFlds[reader.header[i]]; !ok {
@@ -1988,7 +1988,7 @@ func (feed *Feed) checkShapeMeasure(shape *gtfs.Shape, opt *ParseOptions) error 
 
 		if shape.Points[i-1].Sequence == shape.Points[i].Sequence {
 			e := fmt.Errorf("in shape '%s' for point with seq=%d: stop time sequence collision. Sequence has to increase along shape", shape.Id, shape.Points[i].Sequence)
-			if feed.opts.DropErroneous {
+			if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedStopTimes++
 				shape.Points = shape.Points[:i+copy(shape.Points[i:], shape.Points[i+1:])]
 				feed.warn(e)
@@ -2027,9 +2027,9 @@ func (feed *Feed) checkStopTimeMeasure(trip *gtfs.Trip, opt *ParseOptions) error
 	for j := 1; j < len(trip.StopTimes)+deleted; j++ {
 		i := j - deleted
 
-		if trip.StopTimes[i-1].Sequence() == trip.StopTimes[i].Sequence() && !feed.opts.SkipStopTimeValidation {
+		if trip.StopTimes[i-1].Sequence() == trip.StopTimes[i].Sequence() && !feed.Opts.SkipStopTimeValidation {
 			e := fmt.Errorf("in trip '%s' for stoptime with seq=%d: stop time sequence collision. Sequence has to increase along trip", trip.Id, trip.StopTimes[i].Sequence())
-			if feed.opts.DropErroneous {
+			if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedStopTimes++
 				trip.StopTimes = trip.StopTimes[:i+copy(trip.StopTimes[i:], trip.StopTimes[i+1:])]
 				feed.warn(e)
@@ -2210,7 +2210,7 @@ func (feed *Feed) getGTFSDir() string {
 }
 
 func (feed *Feed) warn(e error) {
-	if feed.opts.ShowWarnings {
+	if feed.Opts.ShowWarnings {
 		fmt.Fprintln(os.Stderr, "WARNING: "+e.Error())
 	}
 }

--- a/feed.go
+++ b/feed.go
@@ -97,6 +97,7 @@ type CsvFile struct {
 // A ParseOptions object holds options for parsing a the feed
 type ParseOptions struct {
 	UseDefValueOnError           bool
+	SkipStopTimeValidation       bool
 	DropErroneous                bool
 	DryRun                       bool
 	CheckNullCoordinates         bool
@@ -229,7 +230,7 @@ func NewFeed() *Feed {
 		NumShpPoints:          0,
 		NumStopTimes:          0,
 		fastParsePossible:     true,
-		opts:                  ParseOptions{false, false, false, false, "", "", false, false, false, false, gtfs.Date{}, gtfs.Date{}, make([]Polygon, 0), false, make(map[int16]bool, 0), make(map[int16]bool, 0), false, false, false, false},
+		opts:                  ParseOptions{false, false, false, false, false, "", "", false, false, false, false, gtfs.Date{}, gtfs.Date{}, make([]Polygon, 0), false, make(map[int16]bool, 0), make(map[int16]bool, 0), false, false, false, false},
 	}
 	g.lastString = &g.emptyString
 
@@ -2026,7 +2027,7 @@ func (feed *Feed) checkStopTimeMeasure(trip *gtfs.Trip, opt *ParseOptions) error
 	for j := 1; j < len(trip.StopTimes)+deleted; j++ {
 		i := j - deleted
 
-		if trip.StopTimes[i-1].Sequence() == trip.StopTimes[i].Sequence() {
+		if trip.StopTimes[i-1].Sequence() == trip.StopTimes[i].Sequence() && !feed.opts.SkipStopTimeValidation {
 			e := fmt.Errorf("in trip '%s' for stoptime with seq=%d: stop time sequence collision. Sequence has to increase along trip", trip.Id, trip.StopTimes[i].Sequence())
 			if feed.opts.DropErroneous {
 				feed.ErrorStats.DroppedStopTimes++

--- a/feed.go
+++ b/feed.go
@@ -2027,7 +2027,7 @@ func (feed *Feed) checkStopTimeMeasure(trip *gtfs.Trip, opt *ParseOptions) error
 	for j := 1; j < len(trip.StopTimes)+deleted; j++ {
 		i := j - deleted
 
-		if trip.StopTimes[i-1].Sequence() == trip.StopTimes[i].Sequence() && !feed.Opts.SkipStopTimeValidation {
+		if trip.StopTimes[i-1].Sequence() == trip.StopTimes[i].Sequence() {
 			e := fmt.Errorf("in trip '%s' for stoptime with seq=%d: stop time sequence collision. Sequence has to increase along trip", trip.Id, trip.StopTimes[i].Sequence())
 			if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedStopTimes++
@@ -2040,7 +2040,7 @@ func (feed *Feed) checkStopTimeMeasure(trip *gtfs.Trip, opt *ParseOptions) error
 			}
 		}
 
-		if !trip.StopTimes[i-1].Departure_time().Empty() && !trip.StopTimes[i].Arrival_time().Empty() && trip.StopTimes[i-1].Departure_time().SecondsSinceMidnight() > trip.StopTimes[i].Arrival_time().SecondsSinceMidnight() {
+		if (!trip.StopTimes[i-1].Departure_time().Empty() && !trip.StopTimes[i].Arrival_time().Empty() && trip.StopTimes[i-1].Departure_time().SecondsSinceMidnight() > trip.StopTimes[i].Arrival_time().SecondsSinceMidnight()) && !feed.Opts.SkipStopTimeValidation {
 			e := fmt.Errorf("in trip '%s' for stoptime with seq=%d the arrival time is before the departure in the previous station", trip.Id, trip.StopTimes[i].Sequence())
 			if opt.DropErroneous {
 				feed.ErrorStats.DroppedStopTimes++

--- a/feed.go
+++ b/feed.go
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a GPL v2
 // license that can be found in the LICENSE file
 
-package gtfsparser
+package gtfsparserwr
 
 import (
 	// "archive/zip"

--- a/feed_reader.go
+++ b/feed_reader.go
@@ -1,255 +1,37 @@
-// Copyright 2023 Patrick Brosi
-// Authors: info@patrickbrosi.de
-//
-// Use of this source code is governed by a GPL v2
-// license that can be found in the LICENSE file
-
 package gtfsparser
 
 import (
-	// "archive/zip"
+	"archive/zip"
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	url "net/url"
-	"os"
-	opath "path"
 	"sort"
 	"strings"
-	"unicode"
 
-	"github.com/klauspost/compress/zip"
 	"github.com/Leocraft1/gtfsparser-with-reader/gtfs"
 )
 
-// Holds the original column ordering
-type ColOrders struct {
-	Agencies           []string
-	Stops              []string
-	Routes             []string
-	Trips              []string
-	StopTimes          []string
-	Frequencies        []string
-	Calendar           []string
-	CalendarDates      []string
-	FareAttributes     []string
-	FareAttributeRules []string
-	Shapes             []string
-	Levels             []string
-	Pathways           []string
-	Transfers          []string
-	FeedInfos          []string
-	Attributions       []string
+// Parse the GTFS data from the specified io.Reader into the feed
+func (feed *Feed) ParseReader(reader io.Reader) error {
+	return feed.PrefixParseReader(reader, "")
 }
 
-type Polygon struct {
-	OuterRing  [][2]float64
-	InnerRings [][][2]float64
-	ll         [2]float64
-	ur         [2]float64
-}
-
-// NewPolygon creates a new Polygon from an outer ring
-func NewPolygon(outer [][2]float64, inners [][][2]float64) Polygon {
-	poly := Polygon{outer, inners, [2]float64{math.MaxFloat64, math.MaxFloat64}, [2]float64{-math.MaxFloat64, -math.MaxFloat64}}
-
-	for _, p := range outer {
-		if p[0] < poly.ll[0] {
-			poly.ll[0] = p[0]
-		}
-		if p[1] < poly.ll[1] {
-			poly.ll[1] = p[1]
-		}
-		if p[0] > poly.ur[0] {
-			poly.ur[0] = p[0]
-		}
-		if p[1] > poly.ur[1] {
-			poly.ur[1] = p[1]
-		}
-	}
-
-	for _, inner := range inners {
-		for _, p := range inner {
-			if p[0] < poly.ll[0] {
-				poly.ll[0] = p[0]
-			}
-			if p[1] < poly.ll[1] {
-				poly.ll[1] = p[1]
-			}
-			if p[0] > poly.ur[0] {
-				poly.ur[0] = p[0]
-			}
-			if p[1] > poly.ur[1] {
-				poly.ur[1] = p[1]
-			}
-		}
-	}
-
-	return poly
-}
-
-type CsvFile struct {
-	Header []string
-	Data   [][]string
-}
-
-// A ParseOptions object holds options for parsing a the feed
-type ParseOptions struct {
-	UseDefValueOnError           bool
-	DropErroneous                bool
-	DryRun                       bool
-	CheckNullCoordinates         bool
-	EmptyStringRepl              string
-	EmptyAgencyUrlRepl           string
-	ZipFix                       bool
-	ShowWarnings                 bool
-	DropShapes                   bool
-	KeepAddFlds                  bool
-	DateFilterStart              gtfs.Date
-	DateFilterEnd                gtfs.Date
-	PolygonFilter                []Polygon
-	UseStandardRouteTypes        bool
-	MOTFilter                    map[int16]bool
-	MOTFilterNeg                 map[int16]bool
-	AssumeCleanCsv               bool
-	RemoveFillers                bool
-	UseGoogleSupportedRouteTypes bool
-	DropSingleStopTrips          bool
-}
-
-type ErrStats struct {
-	DroppedAgencies           int
-	DroppedStops              int
-	DroppedRoutes             int
-	DroppedTrips              int
-	DroppedStopTimes          int
-	DroppedFrequencies        int
-	DroppedServices           int
-	DroppedFareAttributes     int
-	DroppedFareAttributeRules int
-	DroppedAttributions       int
-	DroppedShapes             int
-	DroppedLevels             int
-	DroppedPathways           int
-	DroppedTransfers          int
-	DroppedFeedInfos          int
-	DroppedTranslations       int
-	NumTranslations           int
-}
-
-// Feed represents a single GTFS feed
-type Feed struct {
-	Agencies       map[string]*gtfs.Agency
-	Stops          map[string]*gtfs.Stop
-	Routes         map[string]*gtfs.Route
-	Trips          map[string]*gtfs.Trip
-	Services       map[string]*gtfs.Service
-	FareAttributes map[string]*gtfs.FareAttribute
-	Shapes         map[string]*gtfs.Shape
-	Levels         map[string]*gtfs.Level
-	Pathways       map[string]*gtfs.Pathway
-	Transfers      map[gtfs.TransferKey]gtfs.TransferVal
-	FeedInfos      []*gtfs.FeedInfo
-
-	StopsAddFlds          map[string]map[string]string
-	AgenciesAddFlds       map[string]map[string]string
-	RoutesAddFlds         map[string]map[string]string
-	TripsAddFlds          map[string]map[string]string
-	StopTimesAddFlds      map[string]map[string]map[int]string
-	FrequenciesAddFlds    map[string]map[string]map[*gtfs.Frequency]string
-	ShapesAddFlds         map[string]map[string]map[int]string
-	FareRulesAddFlds      map[string]map[string]map[*gtfs.FareAttributeRule]string
-	LevelsAddFlds         map[string]map[string]string
-	PathwaysAddFlds       map[string]map[string]string
-	FareAttributesAddFlds map[string]map[string]string
-	TransfersAddFlds      map[string]map[gtfs.TransferKey]string
-	FeedInfosAddFlds      map[string]map[*gtfs.FeedInfo]string
-	AttributionsAddFlds   map[string]map[*gtfs.Attribution]string
-	TranslationsAddFlds   map[string]map[*gtfs.Translation]string
-
-	// content of files we don't handle
-	AdditionalCsvFiles map[string]CsvFile
-	AdditionalFiles map[string][]byte
-
-	// this only holds feed-wide attributions
-	Attributions []*gtfs.Attribution
-
-	ErrorStats   ErrStats
-	NumShpPoints int
-	NumStopTimes int
-
-	ColOrders ColOrders
-
-	lastTrip  *gtfs.Trip
-	lastShape *gtfs.Shape
-
-	zipFileCloser *zip.ReadCloser
-	curFileHandle *os.File
-
-	lastString  *string
-	emptyString string
-
-	fastParsePossible bool
-
-	opts ParseOptions
-}
-
-// NewFeed creates a new, empty feed
-func NewFeed() *Feed {
-	g := Feed{
-		Agencies:              make(map[string]*gtfs.Agency),
-		Stops:                 make(map[string]*gtfs.Stop),
-		Routes:                make(map[string]*gtfs.Route),
-		Trips:                 make(map[string]*gtfs.Trip),
-		Services:              make(map[string]*gtfs.Service),
-		FareAttributes:        make(map[string]*gtfs.FareAttribute),
-		Shapes:                make(map[string]*gtfs.Shape),
-		Levels:                make(map[string]*gtfs.Level),
-		Pathways:              make(map[string]*gtfs.Pathway),
-		Transfers:             make(map[gtfs.TransferKey]gtfs.TransferVal, 0),
-		FeedInfos:             make([]*gtfs.FeedInfo, 0),
-		StopsAddFlds:          make(map[string]map[string]string),
-		StopTimesAddFlds:      make(map[string]map[string]map[int]string),
-		FrequenciesAddFlds:    make(map[string]map[string]map[*gtfs.Frequency]string),
-		ShapesAddFlds:         make(map[string]map[string]map[int]string),
-		AgenciesAddFlds:       make(map[string]map[string]string),
-		RoutesAddFlds:         make(map[string]map[string]string),
-		TripsAddFlds:          make(map[string]map[string]string),
-		LevelsAddFlds:         make(map[string]map[string]string),
-		PathwaysAddFlds:       make(map[string]map[string]string),
-		FareAttributesAddFlds: make(map[string]map[string]string),
-		FareRulesAddFlds:      make(map[string]map[string]map[*gtfs.FareAttributeRule]string),
-		TransfersAddFlds:      make(map[string]map[gtfs.TransferKey]string),
-		FeedInfosAddFlds:      make(map[string]map[*gtfs.FeedInfo]string),
-		AttributionsAddFlds:   make(map[string]map[*gtfs.Attribution]string),
-		AdditionalCsvFiles:    make(map[string]CsvFile),
-		AdditionalFiles:       make(map[string][]byte),
-		ErrorStats:            ErrStats{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-		NumShpPoints:          0,
-		NumStopTimes:          0,
-		fastParsePossible:     true,
-		opts:                  ParseOptions{false, false, false, false, "", "", false, false, false, false, gtfs.Date{}, gtfs.Date{}, make([]Polygon, 0), false, make(map[int16]bool, 0), make(map[int16]bool, 0), false, false, false, false},
-	}
-	g.lastString = &g.emptyString
-
-	return &g
-}
-
-// SetParseOpts sets the ParseOptions for this feed
-func (feed *Feed) SetParseOpts(opts ParseOptions) {
-	feed.opts = opts
-}
-
-// Parse the GTFS data in the specified folder into the feed
-func (feed *Feed) Parse(path string) error {
-	return feed.PrefixParse(path, "")
-}
-
-// Parse the GTFS data in the specified folder into the feed, use
-// and id prefix
-func (feed *Feed) PrefixParse(path string, prefix string) error {
+// Parse the GTFS data from the specified io.Reader into the feed, with prefix
+func (feed *Feed) PrefixParseReader(reader io.Reader, prefix string) error {
 	var e error
+
+	//Reads the reader parameter and uncompresses it if it's a directory
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return fmt.Errorf("reading gtfs archive: %w", err)
+	}
+
+	zip_reader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return fmt.Errorf("opening gtfs zip: %w", err)
+	}
 
 	// holds stops that are dropped because of geometric filtering.
 	// if these are referenced later, we quietly ignore the error like
@@ -266,45 +48,65 @@ func (feed *Feed) PrefixParse(path string, prefix string) error {
 	// with -De
 	filteredTrips := make(map[string]struct{}, 0)
 
-	e = feed.parseAgencies(path, prefix, feed.opts.EmptyAgencyUrlRepl)
+		e = feed.withFile(zip_reader, "agency.txt", true, func(r io.Reader) error {
+		return feed.parseAgenciesReader(r, prefix, feed.opts.EmptyAgencyUrlRepl)
+	})
 	if e == nil {
-		e = feed.parseFeedInfos(path)
+		e = feed.withFile(zip_reader, "feed_info.txt", false, feed.parseFeedInfosReader)
 	}
 	if e == nil {
-		e = feed.parseLevels(path, prefix)
+		e = feed.withFile(zip_reader, "levels.txt", false, func(r io.Reader) error {
+			return feed.parseLevelsReader(r, prefix)
+		})
 	}
 	if e == nil {
-		e = feed.parseStops(path, prefix, geofilteredStops)
+		e = feed.withFile(zip_reader, "stops.txt", true, func(r io.Reader) error {
+			return feed.parseStopsReader(r, prefix, geofilteredStops)
+		})
+	}
+	if e == nil && !feed.opts.DropShapes {
+		e = feed.withFile(zip_reader, "shapes.txt", false, func(r io.Reader) error {
+			return feed.reserveShapesReader(r, prefix)
+		})
+		if e == nil {
+			e = feed.withFile(zip_reader, "shapes.txt", false, func(r io.Reader) error {
+				return feed.parseShapesReader(r, prefix)
+			})
+		}
 	}
 	if e == nil {
-		e = feed.reserveShapes(path, prefix)
+		e = feed.withFile(zip_reader, "routes.txt", true, func(r io.Reader) error {
+			return feed.parseRoutesReader(r, prefix, filteredRoutes)
+		})
 	}
 	if e == nil {
-		e = feed.parseShapes(path, prefix)
+		e = feed.withFile(zip_reader, "calendar.txt", false, func(r io.Reader) error {
+			return feed.parseCalendarReader(r, prefix)
+		})
 	}
 	if e == nil {
-		e = feed.parseRoutes(path, prefix, filteredRoutes)
+		e = feed.withFile(zip_reader, "calendar_dates.txt", false, func(r io.Reader) error {
+			return feed.parseCalendarDatesReader(r, prefix)
+		})
 	}
 	if e == nil {
-		e = feed.parseCalendar(path, prefix)
+		e = feed.withFile(zip_reader, "trips.txt", true, func(r io.Reader) error {
+			return feed.parseTripsReader(r, prefix, filteredRoutes, filteredTrips)
+		})
 	}
 	if e == nil {
-		e = feed.parseCalendarDates(path, prefix)
+		e = feed.withFile(zip_reader, "stop_times.txt", true, func(r io.Reader) error {
+			return feed.reserveStopTimesReader(r, prefix)
+		})
 	}
 	if e == nil {
-		e = feed.parseTrips(path, prefix, filteredRoutes, filteredTrips)
-	}
-
-	if e == nil {
-		e = feed.reserveStopTimes(path, prefix)
+		e = feed.withFile(zip_reader, "stop_times.txt", true, func(r io.Reader) error {
+			return feed.parseStopTimesReader(r, prefix, geofilteredStops, filteredTrips)
+		})
 	}
 	if e == nil {
-		e = feed.parseStopTimes(path, prefix, geofilteredStops, filteredTrips)
-	}
-	if e == nil {
-		// remove reservation markers
+		// Remove reservation markers
 		for tripId, t := range feed.Trips {
-			// might be nil on dry run
 			if t != nil && t.Id != tripId {
 				t.Id = tripId
 				t.StopTimes = make(gtfs.StopTimes, 0)
@@ -312,59 +114,55 @@ func (feed *Feed) PrefixParse(path string, prefix string) error {
 		}
 	}
 	if e == nil {
-		e = feed.parseFareAttributes(path, prefix)
+		e = feed.withFile(zip_reader, "fare_attributes.txt", false, func(r io.Reader) error {
+			return feed.parseFareAttributesReader(r, prefix)
+		})
 	}
 	if e == nil {
-		e = feed.parseFareAttributeRules(path, prefix, filteredRoutes)
+		e = feed.withFile(zip_reader, "fare_rules.txt", false, func(r io.Reader) error {
+			return feed.parseFareAttributeRulesReader(r, prefix, filteredRoutes)
+		})
 	}
 	if e == nil {
-		e = feed.parseFrequencies(path, prefix, filteredTrips)
+		e = feed.withFile(zip_reader, "frequencies.txt", false, func(r io.Reader) error {
+			return feed.parseFrequenciesReader(r, prefix, filteredTrips)
+		})
 	}
 	if e == nil {
-		e = feed.parseTransfers(path, prefix, geofilteredStops)
+		e = feed.withFile(zip_reader, "transfers.txt", false, func(r io.Reader) error {
+			return feed.parseTransfersReader(r, prefix, geofilteredStops)
+		})
 	}
 	if e == nil {
-		e = feed.parsePathways(path, prefix, geofilteredStops)
+		e = feed.withFile(zip_reader, "pathways.txt", false, func(r io.Reader) error {
+			return feed.parsePathwaysReader(r, prefix, geofilteredStops)
+		})
 	}
 	if e == nil {
-		e = feed.parseAttributions(path, prefix, filteredRoutes, filteredTrips)
+		e = feed.withFile(zip_reader, "attributions.txt", false, func(r io.Reader) error {
+			return feed.parseAttributionsReader(r, prefix, filteredRoutes, filteredTrips)
+		})
 	}
-	// if e == nil {
-	// e = feed.parseTranslations(path, prefix)
-	// }
 
-	//At this point, all possible GTFS is parsed, if there are extra files, it puts them under AdditionalFiles or AdditionalCsvFiles
-	if e == nil && feed.opts.KeepAddFlds {
-		var files []string
-		files, e = feed.listFiles(path)
-		for _, file := range files {
-			if feed.isHandledGTFSFile(file) {
-				continue
-			}
+	// Nessun file/zip handle da chiudere qui: ogni chiamata a withFile
+	// apre e chiude il proprio reader internamente.
 
-			r, e := feed.getFile(path, file)
-			if e != nil {
-				break
-			}
+	if e == nil && (!feed.opts.DateFilterStart.IsEmpty() || !feed.opts.DateFilterEnd.IsEmpty()) {
+		feed.filterServices()
+	}
 
-			// assume that .txt means CSV
-			if strings.HasSuffix(file, ".txt") {
-				reader := NewCsvParser(r, feed.opts.DropErroneous, false)
-				var csv CsvFile
-				csv.Header = reader.GetHeader()
-				for record := reader.ParseCsvLine(); record != nil; record = reader.ParseCsvLine() {
-					csv.Data = append(csv.Data, append(make([]string, 0, len(record)), record...))
-				}
-				feed.AdditionalCsvFiles[file] = csv
-			} else {
-				var data []byte
-				data, e = io.ReadAll(r)
-				feed.AdditionalFiles[file] = data
+	if e == nil && feed.opts.DropSingleStopTrips {
+		for _, t := range feed.Trips {
+			if len(t.StopTimes) < 2 {
+				feed.DeleteTrip(t.Id)
 			}
 		}
 	}
 
-	// close open readers
+	//At this point, all possible GTFS is parsed, if there are extra files, it puts them under AdditionalFiles or AdditionalCsvFiles
+	//Deprecated because of lack of volunty to adapt it
+
+	//Close open readers
 	if feed.zipFileCloser != nil {
 		feed.zipFileCloser.Close()
 		feed.zipFileCloser = nil
@@ -390,118 +188,7 @@ func (feed *Feed) PrefixParse(path string, prefix string) error {
 	return e
 }
 
-func (feed *Feed) filterServices() {
-	toDel := make([]*gtfs.Service, 0)
-	for _, t := range feed.Trips {
-		s := t.Service
-		if (s.IsEmpty() && s.Start_date().IsEmpty() && s.End_date().IsEmpty()) || s.GetFirstActiveDate().IsEmpty() {
-			feed.DeleteTrip(t.Id)
-			toDel = append(toDel, s)
-		}
-	}
-
-	for _, s := range toDel {
-		delete(feed.Services, s.Id())
-	}
-}
-
-func (feed *Feed) getFile(path string, name string) (io.Reader, error) {
-	fileInfo, err := os.Stat(path)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if fileInfo.IsDir() {
-		if feed.curFileHandle != nil {
-			// close previous handle
-			feed.curFileHandle.Close()
-		}
-
-		return os.Open(opath.Join(path, name))
-	}
-
-	var e error
-	if feed.zipFileCloser == nil {
-		// reuse existing opened zip file
-		feed.zipFileCloser, e = zip.OpenReader(path)
-	}
-
-	if e != nil {
-		return nil, e
-	}
-
-	// check for any directory that is a ZIP file
-	zipDir := feed.getGTFSDir()
-
-	if !feed.opts.ZipFix {
-		zipDir = ""
-	}
-
-	for _, f := range feed.zipFileCloser.File {
-		d, n := opath.Split(f.Name)
-		if d == zipDir && n == name {
-			return f.Open()
-		}
-	}
-
-	return nil, errors.New("not found")
-}
-
-func (feed *Feed) listFiles(path string) ([]string, error) {
-	var e error
-	var result []string
-
-	fileInfo, e := os.Stat(path)
-	if e != nil {
-		return nil, e
-	}
-
-	if fileInfo.IsDir() {
-		if feed.curFileHandle != nil {
-			// close previous handle
-			feed.curFileHandle.Close()
-		}
-		entries, e := os.ReadDir(path)
-		for _, f := range entries {
-			result = append(result, f.Name())
-		}
-		return result, e
-	}
-
-	if feed.zipFileCloser == nil {
-		// reuse existing opened zip file
-		feed.zipFileCloser, e = zip.OpenReader(path)
-	}
-
-	if e != nil {
-		return nil, e
-	}
-
-	// check for any directory that is a ZIP file
-	zipDir := feed.getGTFSDir()
-
-	if !feed.opts.ZipFix {
-		zipDir = ""
-	}
-
-	for _, f := range feed.zipFileCloser.File {
-		d, n := opath.Split(f.Name)
-		if d == zipDir {
-			result = append(result, n)
-		}
-	}
-
-	return result, nil
-}
-
-func (feed *Feed) parseAgencies(path string, prefix string, fallbackUrl string) (err error) {
-	file, e := feed.getFile(path, "agency.txt")
-
-	if e != nil {
-		return errors.New("could not open required file agency.txt")
-	}
-
+func (feed *Feed) parseAgenciesReader(file io.Reader, prefix string, fallbackUrl string) (err error) {
 	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
 
 	defer func() {
@@ -509,6 +196,7 @@ func (feed *Feed) parseAgencies(path string, prefix string, fallbackUrl string) 
 			err = ParseError{"agency.txt", reader.Curline, r.(error).Error()}
 		}
 	}()
+	var e error
 
 	var record []string
 	flds := AgencyFields{
@@ -584,13 +272,7 @@ func (feed *Feed) parseAgencies(path string, prefix string, fallbackUrl string) 
 	return e
 }
 
-func (feed *Feed) parseStops(path string, prefix string, geofiltered map[string]struct{}) (err error) {
-	file, e := feed.getFile(path, "stops.txt")
-
-	if e != nil {
-		return errors.New("could not open required file stops.txt")
-	}
-
+func (feed *Feed) parseStopsReader(file io.Reader, prefix string, geofiltered map[string]struct{}) (err error) {
 	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
 
 	defer func() {
@@ -598,6 +280,7 @@ func (feed *Feed) parseStops(path string, prefix string, geofiltered map[string]
 			err = ParseError{"stops.txt", reader.Curline, r.(error).Error()}
 		}
 	}()
+	var e error
 
 	var record []string
 	flds := StopFields{
@@ -737,13 +420,7 @@ func (feed *Feed) parseStops(path string, prefix string, geofiltered map[string]
 	return e
 }
 
-func (feed *Feed) parseRoutes(path string, prefix string, filtered map[string]struct{}) (err error) {
-	file, e := feed.getFile(path, "routes.txt")
-
-	if e != nil {
-		return errors.New("could not open required file routes.txt")
-	}
-
+func (feed *Feed) parseRoutesReader(file io.Reader, prefix string, filtered map[string]struct{}) (err error) {
 	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
 
 	defer func() {
@@ -752,6 +429,7 @@ func (feed *Feed) parseRoutes(path string, prefix string, filtered map[string]st
 		}
 	}()
 
+	var e error
 	var record []string
 	flds := RouteFields{
 		routeId:           reader.headeridx.GetFldId("route_id", -1),
@@ -835,14 +513,7 @@ func (feed *Feed) parseRoutes(path string, prefix string, filtered map[string]st
 	return e
 }
 
-func (feed *Feed) parseCalendar(path string, prefix string) (err error) {
-	file, e := feed.getFile(path, "calendar.txt")
-
-	if e != nil {
-		return nil
-	}
-
-	// reader := NewCsvParser(file, feed.opts.DropErroneous, feed.opts.AssumeCleanCsv && !feed.opts.KeepAddFlds)
+func (feed *Feed) parseCalendarReader(file io.Reader, prefix string) (err error) {
 	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
 
 	defer func() {
@@ -851,6 +522,7 @@ func (feed *Feed) parseCalendar(path string, prefix string) (err error) {
 		}
 	}()
 
+	var e error
 	var record []string
 	flds := CalendarFields{
 		serviceId: reader.headeridx.GetFldId("service_id", -1),
@@ -912,14 +584,7 @@ func (feed *Feed) parseCalendar(path string, prefix string) (err error) {
 	return e
 }
 
-func (feed *Feed) parseCalendarDates(path string, prefix string) (err error) {
-	file, e := feed.getFile(path, "calendar_dates.txt")
-
-	if e != nil {
-		return nil
-	}
-
-	// reader := NewCsvParser(file, feed.opts.DropErroneous, feed.opts.AssumeCleanCsv && !feed.opts.KeepAddFlds)
+func (feed *Feed) parseCalendarDatesReader(file io.Reader, prefix string) (err error) {
 	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
 
 	defer func() {
@@ -928,6 +593,7 @@ func (feed *Feed) parseCalendarDates(path string, prefix string) (err error) {
 		}
 	}()
 
+	var e error
 	var record []string
 	flds := CalendarDatesFields{
 		serviceId:     reader.headeridx.GetFldId("service_id", -1),
@@ -963,13 +629,7 @@ func (feed *Feed) parseCalendarDates(path string, prefix string) (err error) {
 	return e
 }
 
-func (feed *Feed) parseTrips(path string, prefix string, filteredRoutes map[string]struct{}, filteredTrips map[string]struct{}) (err error) {
-	file, e := feed.getFile(path, "trips.txt")
-
-	if e != nil {
-		return errors.New("could not open required file trips.txt")
-	}
-
+func (feed *Feed) parseTripsReader(file io.Reader, prefix string, filteredRoutes map[string]struct{}, filteredTrips map[string]struct{}) (err error) {
 	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
 
 	defer func() {
@@ -978,6 +638,7 @@ func (feed *Feed) parseTrips(path string, prefix string, filteredRoutes map[stri
 		}
 	}()
 
+	var e error
 	var record []string
 	flds := TripFields{
 		tripId:               reader.headeridx.GetFldId("trip_id", -1),
@@ -1048,14 +709,9 @@ func (feed *Feed) parseTrips(path string, prefix string, filteredRoutes map[stri
 	return e
 }
 
-func (feed *Feed) reserveShapes(path string, prefix string) (err error) {
+func (feed *Feed) reserveShapesReader(file io.Reader, prefix string) (err error) {
 	if feed.opts.DropShapes {
 		return
-	}
-	file, e := feed.getFile(path, "shapes.txt")
-
-	if e != nil {
-		return nil
 	}
 
 	reader := NewCsvParser(file, feed.opts.DropErroneous, feed.opts.AssumeCleanCsv && !feed.opts.KeepAddFlds)
@@ -1066,6 +722,7 @@ func (feed *Feed) reserveShapes(path string, prefix string) (err error) {
 		}
 	}()
 
+	var e error
 	var record []string
 	flds := ShapeFields{
 		shapeId:           reader.headeridx.GetFldId("shape_id", -1),
@@ -1089,16 +746,10 @@ func (feed *Feed) reserveShapes(path string, prefix string) (err error) {
 	return e
 }
 
-func (feed *Feed) parseShapes(path string, prefix string) (err error) {
+func (feed *Feed) parseShapesReader(file io.Reader, prefix string) (err error) {
 	if feed.opts.DropShapes {
 		return
 	}
-	file, e := feed.getFile(path, "shapes.txt")
-
-	if e != nil {
-		return nil
-	}
-
 	reader := NewCsvParser(file, feed.opts.DropErroneous, feed.opts.AssumeCleanCsv && !feed.opts.KeepAddFlds)
 
 	defer func() {
@@ -1107,6 +758,7 @@ func (feed *Feed) parseShapes(path string, prefix string) (err error) {
 		}
 	}()
 
+	var e error
 	var record []string
 	flds := ShapeFields{
 		shapeId:           reader.headeridx.GetFldId("shape_id", -1),
@@ -1187,13 +839,9 @@ func (feed *Feed) parseShapes(path string, prefix string) (err error) {
 	return e
 }
 
-func (feed *Feed) reserveStopTimes(path string, prefix string) (err error) {
-	file, e := feed.getFile(path, "stop_times.txt")
-
-	if e != nil {
-		return errors.New("could not open required file stop_times.txt")
-	}
+func (feed *Feed) reserveStopTimesReader(file io.Reader, prefix string) (err error) {
 	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	file2 := file
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -1201,6 +849,7 @@ func (feed *Feed) reserveStopTimes(path string, prefix string) (err error) {
 		}
 	}()
 
+	var e error
 	var record []string
 	flds := StopTimeFields{
 		tripId:            reader.headeridx.GetFldId("trip_id", -1),
@@ -1217,13 +866,11 @@ func (feed *Feed) reserveStopTimes(path string, prefix string) (err error) {
 		timepoint:         reader.headeridx.GetFldId("timepoint", -12),
 	}
 
-	file, e = feed.getFile(path, "stop_times.txt")
-
 	if e != nil {
 		return errors.New("could not open required file stop_times.txt")
 	}
 
-	reader = NewCsvParser(file, feed.opts.DropErroneous, feed.opts.AssumeCleanCsv && flds.stopHeadsign < 0 && !feed.opts.KeepAddFlds)
+	reader = NewCsvParser(file2, feed.opts.DropErroneous, feed.opts.AssumeCleanCsv && flds.stopHeadsign < 0 && !feed.opts.KeepAddFlds)
 
 	for record = reader.ParseCsvLine(); record != nil; record = reader.ParseCsvLine() {
 		reserveStopTime(record, flds, feed, prefix)
@@ -1232,13 +879,9 @@ func (feed *Feed) reserveStopTimes(path string, prefix string) (err error) {
 	return e
 }
 
-func (feed *Feed) parseStopTimes(path string, prefix string, geofiltered map[string]struct{}, filteredTrips map[string]struct{}) (err error) {
-	file, e := feed.getFile(path, "stop_times.txt")
-
-	if e != nil {
-		return errors.New("could not open required file stop_times.txt")
-	}
+func (feed *Feed) parseStopTimesReader(file io.Reader, prefix string, geofiltered map[string]struct{}, filteredTrips map[string]struct{}) (err error) {
 	reader := NewCsvParser(file, feed.opts.DropErroneous, feed.opts.AssumeCleanCsv && !feed.opts.KeepAddFlds)
+	file2 := file
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -1246,6 +889,7 @@ func (feed *Feed) parseStopTimes(path string, prefix string, geofiltered map[str
 		}
 	}()
 
+	var e error
 	var record []string
 	flds := StopTimeFields{
 		tripId:            reader.headeridx.GetFldId("trip_id", -1),
@@ -1268,13 +912,11 @@ func (feed *Feed) parseStopTimes(path string, prefix string, geofiltered map[str
 		addFlds = addiFields(reader.header, flds)
 	}
 
-	file, e = feed.getFile(path, "stop_times.txt")
-
 	if e != nil {
 		return errors.New("could not open required file stop_times.txt")
 	}
 
-	reader = NewCsvParser(file, feed.opts.DropErroneous, feed.opts.AssumeCleanCsv && flds.stopHeadsign < 0)
+	reader = NewCsvParser(file2, feed.opts.DropErroneous, feed.opts.AssumeCleanCsv && flds.stopHeadsign < 0)
 
 	i := 0
 
@@ -1337,12 +979,7 @@ func (feed *Feed) parseStopTimes(path string, prefix string, geofiltered map[str
 	return e
 }
 
-func (feed *Feed) parseFrequencies(path string, prefix string, filteredTrips map[string]struct{}) (err error) {
-	file, e := feed.getFile(path, "frequencies.txt")
-
-	if e != nil {
-		return nil
-	}
+func (feed *Feed) parseFrequenciesReader(file io.Reader, prefix string, filteredTrips map[string]struct{}) (err error) {
 	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
 
 	defer func() {
@@ -1351,6 +988,7 @@ func (feed *Feed) parseFrequencies(path string, prefix string, filteredTrips map
 		}
 	}()
 
+	var e error
 	var record []string
 	flds := FrequencyFields{
 		tripId:      reader.headeridx.GetFldId("trip_id", -1),
@@ -1405,12 +1043,7 @@ func (feed *Feed) parseFrequencies(path string, prefix string, filteredTrips map
 	return e
 }
 
-func (feed *Feed) parseFareAttributes(path string, prefix string) (err error) {
-	file, e := feed.getFile(path, "fare_attributes.txt")
-
-	if e != nil {
-		return nil
-	}
+func (feed *Feed) parseFareAttributesReader(file io.Reader, prefix string) (err error) {
 	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
 
 	defer func() {
@@ -1419,6 +1052,7 @@ func (feed *Feed) parseFareAttributes(path string, prefix string) (err error) {
 		}
 	}()
 
+	var e error
 	var record []string
 	flds := FareAttributeFields{
 		fareId:           reader.headeridx.GetFldId("fare_id", -1),
@@ -1465,12 +1099,7 @@ func (feed *Feed) parseFareAttributes(path string, prefix string) (err error) {
 	return e
 }
 
-func (feed *Feed) parseFareAttributeRules(path string, prefix string, filteredRoutes map[string]struct{}) (err error) {
-	file, e := feed.getFile(path, "fare_rules.txt")
-
-	if e != nil {
-		return nil
-	}
+func (feed *Feed) parseFareAttributeRulesReader(file io.Reader, prefix string, filteredRoutes map[string]struct{}) (err error) {
 	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
 
 	defer func() {
@@ -1479,6 +1108,7 @@ func (feed *Feed) parseFareAttributeRules(path string, prefix string, filteredRo
 		}
 	}()
 
+	var e error
 	var record []string
 	flds := FareRuleFields{
 		fareId:        reader.headeridx.GetFldId("fare_id", -1),
@@ -1534,12 +1164,7 @@ func (feed *Feed) parseFareAttributeRules(path string, prefix string, filteredRo
 	return e
 }
 
-func (feed *Feed) parseTransfers(path string, prefix string, geofiltered map[string]struct{}) (err error) {
-	file, e := feed.getFile(path, "transfers.txt")
-
-	if e != nil {
-		return nil
-	}
+func (feed *Feed) parseTransfersReader(file io.Reader, prefix string, geofiltered map[string]struct{}) (err error) {
 	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
 
 	defer func() {
@@ -1548,6 +1173,7 @@ func (feed *Feed) parseTransfers(path string, prefix string, geofiltered map[str
 		}
 	}()
 
+	var e error
 	var record []string
 	flds := TransferFields{
 		FromStopId:      reader.headeridx.GetFldId("from_stop_id", -1),
@@ -1611,12 +1237,7 @@ func (feed *Feed) parseTransfers(path string, prefix string, geofiltered map[str
 	return e
 }
 
-func (feed *Feed) parsePathways(path string, prefix string, geofiltered map[string]struct{}) (err error) {
-	file, e := feed.getFile(path, "pathways.txt")
-
-	if e != nil {
-		return nil
-	}
+func (feed *Feed) parsePathwaysReader(file io.Reader, prefix string, geofiltered map[string]struct{}) (err error) {
 	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
 
 	defer func() {
@@ -1625,6 +1246,7 @@ func (feed *Feed) parsePathways(path string, prefix string, geofiltered map[stri
 		}
 	}()
 
+	var e error
 	var record []string
 	flds := PathwayFields{
 		pathwayId:            reader.headeridx.GetFldId("pathway_id", -1),
@@ -1689,12 +1311,7 @@ func (feed *Feed) parsePathways(path string, prefix string, geofiltered map[stri
 	return e
 }
 
-func (feed *Feed) parseTranslations(path string, prefix string) (err error) {
-	file, e := feed.getFile(path, "translations.txt")
-
-	if e != nil {
-		return nil
-	}
+func (feed *Feed) parseTranslationsReader(file io.Reader, prefix string) (err error) {
 	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
 
 	defer func() {
@@ -1703,6 +1320,7 @@ func (feed *Feed) parseTranslations(path string, prefix string) (err error) {
 		}
 	}()
 
+	var e error
 	var record []string
 	flds := TranslationFields{
 		tableName:   reader.headeridx.GetFldId("table_name", -1),
@@ -1750,12 +1368,7 @@ func (feed *Feed) parseTranslations(path string, prefix string) (err error) {
 	return e
 }
 
-func (feed *Feed) parseAttributions(path string, prefix string, filteredRoutes map[string]struct{}, filteredTrips map[string]struct{}) (err error) {
-	file, e := feed.getFile(path, "attributions.txt")
-
-	if e != nil {
-		return nil
-	}
+func (feed *Feed) parseAttributionsReader(file io.Reader, prefix string, filteredRoutes map[string]struct{}, filteredTrips map[string]struct{}) (err error) {
 	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
 
 	defer func() {
@@ -1766,6 +1379,7 @@ func (feed *Feed) parseAttributions(path string, prefix string, filteredRoutes m
 
 	ids := make(map[string]bool)
 
+	var e error
 	var record []string
 	flds := AttributionFields{
 		attributionId:    reader.headeridx.GetFldId("attribution_id", -1),
@@ -1856,12 +1470,7 @@ func (feed *Feed) parseAttributions(path string, prefix string, filteredRoutes m
 	return e
 }
 
-func (feed *Feed) parseLevels(path string, idprefix string) (err error) {
-	file, e := feed.getFile(path, "levels.txt")
-
-	if e != nil {
-		return nil
-	}
+func (feed *Feed) parseLevelsReader(file io.Reader, idprefix string) (err error) {
 	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
 
 	defer func() {
@@ -1870,6 +1479,7 @@ func (feed *Feed) parseLevels(path string, idprefix string) (err error) {
 		}
 	}()
 
+	var e error
 	var record []string
 	flds := LevelFields{
 		levelId:    reader.headeridx.GetFldId("level_id", -1),
@@ -1917,12 +1527,7 @@ func (feed *Feed) parseLevels(path string, idprefix string) (err error) {
 	return e
 }
 
-func (feed *Feed) parseFeedInfos(path string) (err error) {
-	file, e := feed.getFile(path, "feed_info.txt")
-
-	if e != nil {
-		return nil
-	}
+func (feed *Feed) parseFeedInfosReader(file io.Reader) (err error) {
 	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
 
 	defer func() {
@@ -1931,6 +1536,7 @@ func (feed *Feed) parseFeedInfos(path string) (err error) {
 		}
 	}()
 
+	var e error
 	var record []string
 	flds := FeedInfoFields{
 		feedPublisherName: reader.headeridx.GetFldId("feed_publisher_name", -1),
@@ -1979,389 +1585,41 @@ func (feed *Feed) parseFeedInfos(path string) (err error) {
 	return e
 }
 
-func (feed *Feed) checkShapeMeasure(shape *gtfs.Shape, opt *ParseOptions) error {
-	max := float32(math.Inf(-1))
-	deleted := 0
-	for j := 1; j < len(shape.Points)+deleted; j++ {
-		i := j - deleted
-
-		if shape.Points[i-1].Sequence == shape.Points[i].Sequence {
-			e := fmt.Errorf("in shape '%s' for point with seq=%d: stop time sequence collision. Sequence has to increase along shape", shape.Id, shape.Points[i].Sequence)
-			if feed.opts.DropErroneous {
-				feed.ErrorStats.DroppedStopTimes++
-				shape.Points = shape.Points[:i+copy(shape.Points[i:], shape.Points[i+1:])]
-				feed.warn(e)
-				deleted++
-				continue
-			} else {
-				return e
-			}
+// withFile locates name inside the zip archive, opens it, invokes fn with
+// its content reader, and closes it afterwards. If the file is missing and
+// required is false, fn is silently skipped.
+// If required is true and the file is missing, an error is returned.
+func (feed *Feed) withFile(zr *zip.Reader, name string, required bool, fn func(io.Reader) error) error {
+	f := findZipFile(zr, name)
+	if f == nil {
+		if required {
+			return fmt.Errorf("required file %s not found in gtfs archive", name)
 		}
+		return nil
+	}
 
-		if shape.Points[i-1].HasDistanceTraveled() && shape.Points[i-1].Dist_traveled > max {
-			max = shape.Points[i-1].Dist_traveled
+	rc, err := f.Open()
+	if err != nil {
+		return fmt.Errorf("opening %s: %w", name, err)
+	}
+	defer rc.Close()
+
+	return fn(rc)
+}
+
+// findZipFile looks up a GTFS file by name. Falls back to matching the
+// basename in case the .txt files are nested inside a subfolder within
+// the zip (some non-conformant feeds do this).
+func findZipFile(zr *zip.Reader, name string) *zip.File {
+	for _, f := range zr.File {
+		if f.Name == name {
+			return f
 		}
-
-		if shape.Points[i].HasDistanceTraveled() && max > shape.Points[i].Dist_traveled {
-			e := fmt.Errorf("in shape '%s' for point with seq=%d shape_dist_traveled does not increase along with stop_sequence (%f > %f)", shape.Id, shape.Points[i].Sequence, max, shape.Points[i].Dist_traveled)
-			if opt.UseDefValueOnError {
-				shape.Points[i].Dist_traveled = float32(math.NaN())
-				feed.warn(e)
-			} else if opt.DropErroneous {
-				feed.ErrorStats.DroppedShapes++
-				feed.warn(e)
-				shape.Points = shape.Points[:i+copy(shape.Points[i:], shape.Points[i+1:])]
-				deleted++
-			} else {
-				return e
-			}
+	}
+	for _, f := range zr.File {
+		if strings.HasSuffix(f.Name, "/"+name) {
+			return f
 		}
 	}
 	return nil
-}
-
-func (feed *Feed) checkStopTimeMeasure(trip *gtfs.Trip, opt *ParseOptions) error {
-	max := float32(math.Inf(-1))
-	deleted := 0
-	for j := 1; j < len(trip.StopTimes)+deleted; j++ {
-		i := j - deleted
-
-		if trip.StopTimes[i-1].Sequence() == trip.StopTimes[i].Sequence() {
-			e := fmt.Errorf("in trip '%s' for stoptime with seq=%d: stop time sequence collision. Sequence has to increase along trip", trip.Id, trip.StopTimes[i].Sequence())
-			if feed.opts.DropErroneous {
-				feed.ErrorStats.DroppedStopTimes++
-				trip.StopTimes = trip.StopTimes[:i+copy(trip.StopTimes[i:], trip.StopTimes[i+1:])]
-				feed.warn(e)
-				deleted++
-				continue
-			} else {
-				return e
-			}
-		}
-
-		if !trip.StopTimes[i-1].Departure_time().Empty() && !trip.StopTimes[i].Arrival_time().Empty() && trip.StopTimes[i-1].Departure_time().SecondsSinceMidnight() > trip.StopTimes[i].Arrival_time().SecondsSinceMidnight() {
-			e := fmt.Errorf("in trip '%s' for stoptime with seq=%d the arrival time is before the departure in the previous station", trip.Id, trip.StopTimes[i].Sequence())
-			if opt.DropErroneous {
-				feed.ErrorStats.DroppedStopTimes++
-				trip.StopTimes = trip.StopTimes[:i+copy(trip.StopTimes[i:], trip.StopTimes[i+1:])]
-				feed.warn(e)
-				deleted++
-				continue
-			} else {
-				return e
-			}
-		}
-
-		if trip.StopTimes[i-1].HasDistanceTraveled() && trip.StopTimes[i-1].Shape_dist_traveled() > max {
-			max = trip.StopTimes[i-1].Shape_dist_traveled()
-		}
-
-		if trip.StopTimes[i].HasDistanceTraveled() && max > trip.StopTimes[i].Shape_dist_traveled() {
-			e := fmt.Errorf("in trip '%s' for stoptime with seq=%d shape_dist_traveled does not increase along with stop_sequence (%f > %f)", trip.Id, trip.StopTimes[i].Sequence(), max, trip.StopTimes[i].Shape_dist_traveled())
-			if opt.UseDefValueOnError {
-				trip.StopTimes[i].SetShape_dist_traveled(float32(math.NaN()))
-				feed.warn(e)
-			} else if opt.DropErroneous {
-				trip.StopTimes = trip.StopTimes[:i+copy(trip.StopTimes[i:], trip.StopTimes[i+1:])]
-				feed.ErrorStats.DroppedStopTimes++
-				feed.warn(e)
-				deleted++
-				continue
-			} else {
-				return e
-			}
-		}
-	}
-	return nil
-}
-
-func (p *Polygon) PolyContains(x float64, y float64) bool {
-	if len(p.OuterRing) == 0 {
-		return false
-	}
-
-	// first check if contained in bounding box
-	if x < p.ll[0] || x > p.ur[0] || y < p.ll[1] || y > p.ur[1] {
-		return false
-	}
-
-	// see https://de.wikipedia.org/wiki/Punkt-in-Polygon-Test_nach_Jordan
-	c := int8(-1)
-
-	for i := 1; i < len(p.OuterRing); i++ {
-		c *= polyContCheck(x, y, p.OuterRing[i-1][0], p.OuterRing[i-1][1], p.OuterRing[i][0], p.OuterRing[i][1])
-		if c == 0 {
-			return true
-		}
-	}
-
-	c *= polyContCheck(x, y, p.OuterRing[len(p.OuterRing)-1][0], p.OuterRing[len(p.OuterRing)-1][1], p.OuterRing[0][0], p.OuterRing[0][1])
-
-	if c < 0 {
-		return false
-	}
-
-	for _, innerRing := range p.InnerRings {
-		c = int8(-1)
-
-		for i := 1; i < len(innerRing); i++ {
-			c *= polyContCheck(x, y, innerRing[i-1][0], innerRing[i-1][1], innerRing[i][0], innerRing[i][1])
-			if c == 0 {
-				return false
-			}
-		}
-
-		c *= polyContCheck(x, y, innerRing[len(innerRing)-1][0], innerRing[len(innerRing)-1][1], innerRing[0][0], innerRing[0][1])
-
-		if c >= 0 {
-			return false
-		}
-	}
-
-	return true
-}
-
-func polyContCheck(ax float64, ay float64, bx float64, by float64, cx float64, cy float64) int8 {
-	EPSILON := 0.00000001
-	if ay == by && ay == cy {
-		if !((bx <= ax && ax <= cx) ||
-			(cx <= ax && ax <= bx)) {
-			return 1
-		}
-		return 0
-	}
-	if math.Abs(ay-by) < EPSILON &&
-		math.Abs(ax-by) < EPSILON {
-		return 0
-	}
-
-	if by > cy {
-		tmpx := bx
-		tmpy := by
-		bx = cx
-		by = cy
-		cx = tmpx
-		cy = tmpy
-	}
-
-	if ay <= by || ay > cy {
-		return 1
-	}
-
-	d := (bx-ax)*(cy-ay) -
-		(by-ay)*(cx-ax)
-
-	if d > 0 {
-		return -1
-	}
-	if d < 0 {
-		return 1
-	}
-	return 0
-}
-
-func (feed *Feed) isHandledGTFSFile(name string) bool {
-	files := map[string]bool{
-		"agency.txt":          true,
-		"stops.txt":           true,
-		"routes.txt":          true,
-		"trips.txt":           true,
-		"stop_times.txt":      true,
-		"calendar.txt":        true,
-		"calendar_dates.txt":  true,
-		"fare_attributes.txt": true,
-		"fare_rules.txt":      true,
-		"shapes.txt":          true,
-		"frequencies.txt":     true,
-		"transfers.txt":       true,
-		"pathways.txt":        true,
-		"levels.txt":          true,
-		"feed_info.txt":       true,
-	}
-
-	return files[name]
-}
-
-func (feed *Feed) getGTFSDir() string {
-	// count number of GTFS file occurances in folders,
-	// return the folder with the most GTFS files
-
-	pathm := make(map[string]int)
-
-
-	for _, f := range feed.zipFileCloser.File {
-		dir, name := opath.Split(f.Name)
-		if feed.isHandledGTFSFile(name) {
-			pathm[dir] = pathm[dir] + 1
-		}
-	}
-
-	ret := ""
-	max := 0
-	for dir := range pathm {
-		if pathm[dir] > max {
-			max = pathm[dir]
-			ret = dir
-		}
-	}
-
-	return ret
-}
-
-func (feed *Feed) warn(e error) {
-	if feed.opts.ShowWarnings {
-		fmt.Fprintln(os.Stderr, "WARNING: "+e.Error())
-	}
-}
-
-func (feed *Feed) DeletePathway(id string) {
-	delete(feed.FareAttributes, id)
-
-	// delete additional fields from CSV
-	for k := range feed.PathwaysAddFlds {
-		delete(feed.PathwaysAddFlds[k], id)
-	}
-}
-
-func (feed *Feed) DeleteFareAttribute(id string) {
-	delete(feed.FareAttributes, id)
-
-	// delete additional fields from CSV
-	for k := range feed.FareRulesAddFlds {
-		delete(feed.FareRulesAddFlds[k], id)
-	}
-
-	for k := range feed.FareAttributesAddFlds {
-		delete(feed.FareAttributesAddFlds[k], id)
-	}
-}
-
-func (feed *Feed) DeleteTrip(id string) {
-	if _, ok := feed.Trips[id]; ok {
-		feed.NumStopTimes -= len(feed.Trips[id].StopTimes)
-		delete(feed.Trips, id)
-	}
-
-	// delete additional fields from CSV
-	for k := range feed.TripsAddFlds {
-		delete(feed.TripsAddFlds[k], id)
-	}
-
-	for k := range feed.StopTimesAddFlds {
-		delete(feed.StopTimesAddFlds[k], id)
-	}
-
-	for k := range feed.FrequenciesAddFlds {
-		delete(feed.FrequenciesAddFlds[k], id)
-	}
-}
-
-func (feed *Feed) DeleteShape(id string) {
-	delete(feed.Shapes, id)
-
-	// delete additional fields from CSV
-	for k := range feed.ShapesAddFlds {
-		delete(feed.ShapesAddFlds[k], id)
-	}
-}
-
-func (feed *Feed) DeleteAgency(id string) {
-	delete(feed.Agencies, id)
-
-	// delete additional fields from CSV
-	for k := range feed.AgenciesAddFlds {
-		delete(feed.AgenciesAddFlds[k], id)
-	}
-}
-
-func (feed *Feed) DeleteRoute(id string) {
-	delete(feed.Routes, id)
-
-	// delete additional fields from CSV
-	for k := range feed.RoutesAddFlds {
-		delete(feed.RoutesAddFlds[k], id)
-	}
-}
-
-func (feed *Feed) DeleteLevel(id string) {
-	delete(feed.Levels, id)
-
-	// delete additional fields from CSV
-	for k := range feed.LevelsAddFlds {
-		delete(feed.LevelsAddFlds[k], id)
-	}
-}
-
-func (feed *Feed) DeleteStop(id string) {
-	delete(feed.Stops, id)
-
-	// delete additional fields from CSV
-	for k := range feed.StopsAddFlds {
-		delete(feed.StopsAddFlds[k], id)
-	}
-}
-
-func (feed *Feed) DeleteTransfer(tk gtfs.TransferKey) {
-	delete(feed.Transfers, tk)
-
-	// delete additional fields from CSV
-	for k := range feed.TransfersAddFlds {
-		delete(feed.TransfersAddFlds[k], tk)
-	}
-}
-
-func (feed *Feed) CleanTransfers() {
-	for tk := range feed.Transfers {
-		if tk.From_stop != nil {
-			if _, in := feed.Stops[tk.From_stop.Id]; !in {
-				feed.DeleteTransfer(tk)
-				continue
-			}
-		}
-		if tk.To_stop != nil {
-			if _, in := feed.Stops[tk.To_stop.Id]; !in {
-				feed.DeleteTransfer(tk)
-				continue
-			}
-		}
-		if tk.From_route != nil {
-			if _, in := feed.Routes[tk.From_route.Id]; !in {
-				feed.DeleteTransfer(tk)
-				continue
-			}
-		}
-		if tk.To_route != nil {
-			if _, in := feed.Routes[tk.To_route.Id]; !in {
-				feed.DeleteTransfer(tk)
-				continue
-			}
-		}
-
-		if tk.From_trip != nil {
-			if _, in := feed.Trips[tk.From_trip.Id]; !in {
-				feed.DeleteTransfer(tk)
-				continue
-			}
-		}
-
-		if tk.To_trip != nil {
-			if _, in := feed.Trips[tk.To_trip.Id]; !in {
-				feed.DeleteTransfer(tk)
-				continue
-			}
-		}
-	}
-}
-
-func (feed *Feed) DeleteService(id string) {
-	delete(feed.Services, id)
-}
-
-func isASCII(s string) bool {
-	for i := 0; i < len(s); i++ {
-		if s[i] > unicode.MaxASCII {
-			return false
-		}
-	}
-	return true
 }

--- a/feed_reader.go
+++ b/feed_reader.go
@@ -48,7 +48,7 @@ func (feed *Feed) PrefixParseReader(reader io.Reader, prefix string) error {
 	// with -De
 	filteredTrips := make(map[string]struct{}, 0)
 
-		e = feed.withFile(zip_reader, "agency.txt", true, func(r io.Reader) error {
+	e = feed.withFile(zip_reader, "agency.txt", true, func(r io.Reader) error {
 		return feed.parseAgenciesReader(r, prefix, feed.opts.EmptyAgencyUrlRepl)
 	})
 	if e == nil {
@@ -1307,63 +1307,6 @@ func (feed *Feed) parsePathwaysReader(file io.Reader, prefix string, geofiltered
 	}
 
 	feed.ColOrders.Pathways = append([]string(nil), reader.header...)
-
-	return e
-}
-
-func (feed *Feed) parseTranslationsReader(file io.Reader, prefix string) (err error) {
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
-
-	defer func() {
-		if r := recover(); r != nil {
-			err = ParseError{"translations.txt", reader.Curline, r.(error).Error()}
-		}
-	}()
-
-	var e error
-	var record []string
-	flds := TranslationFields{
-		tableName:   reader.headeridx.GetFldId("table_name", -1),
-		fieldName:   reader.headeridx.GetFldId("field_name", -2),
-		language:    reader.headeridx.GetFldId("language", -3),
-		translation: reader.headeridx.GetFldId("translation", -4),
-		recordId:    reader.headeridx.GetFldId("record_id", -5),
-		recordSubId: reader.headeridx.GetFldId("record_sub_id", -6),
-		fieldValue:  reader.headeridx.GetFldId("field_value", -7),
-	}
-
-	addFlds := make([]int, 0)
-
-	if feed.opts.KeepAddFlds {
-		addFlds = addiFields(reader.header, flds)
-	}
-
-	for record = reader.ParseCsvLine(); record != nil; record = reader.ParseCsvLine() {
-		trans, e := createTranslation(record, flds, feed, prefix)
-		if e != nil {
-			if feed.opts.DropErroneous {
-				feed.ErrorStats.DroppedTranslations++
-				feed.warn(e)
-				continue
-			} else {
-				panic(e)
-			}
-		}
-
-		feed.ErrorStats.NumTranslations++
-
-		for _, i := range addFlds {
-			if i < len(record) {
-				if _, ok := feed.TranslationsAddFlds[reader.header[i]]; !ok {
-					feed.TranslationsAddFlds[reader.header[i]] = make(map[*gtfs.Translation]string)
-				}
-
-				feed.TranslationsAddFlds[reader.header[i]][trans] = record[i]
-			}
-		}
-	}
-
-	feed.ColOrders.Attributions = append([]string(nil), reader.header...)
 
 	return e
 }

--- a/feed_reader.go
+++ b/feed_reader.go
@@ -1,4 +1,4 @@
-package gtfsparser
+package gtfsparserwr
 
 import (
 	"archive/zip"

--- a/feed_reader.go
+++ b/feed_reader.go
@@ -49,7 +49,7 @@ func (feed *Feed) PrefixParseReader(reader io.Reader, prefix string) error {
 	filteredTrips := make(map[string]struct{}, 0)
 
 	e = feed.withFile(zip_reader, "agency.txt", true, func(r io.Reader) error {
-		return feed.parseAgenciesReader(r, prefix, feed.opts.EmptyAgencyUrlRepl)
+		return feed.parseAgenciesReader(r, prefix, feed.Opts.EmptyAgencyUrlRepl)
 	})
 	if e == nil {
 		e = feed.withFile(zip_reader, "feed_info.txt", false, feed.parseFeedInfosReader)
@@ -64,7 +64,7 @@ func (feed *Feed) PrefixParseReader(reader io.Reader, prefix string) error {
 			return feed.parseStopsReader(r, prefix, geofilteredStops)
 		})
 	}
-	if e == nil && !feed.opts.DropShapes {
+	if e == nil && !feed.Opts.DropShapes {
 		e = feed.withFile(zip_reader, "shapes.txt", false, func(r io.Reader) error {
 			return feed.reserveShapesReader(r, prefix)
 		})
@@ -147,11 +147,11 @@ func (feed *Feed) PrefixParseReader(reader io.Reader, prefix string) error {
 	// Nessun file/zip handle da chiudere qui: ogni chiamata a withFile
 	// apre e chiude il proprio reader internamente.
 
-	if e == nil && (!feed.opts.DateFilterStart.IsEmpty() || !feed.opts.DateFilterEnd.IsEmpty()) {
+	if e == nil && (!feed.Opts.DateFilterStart.IsEmpty() || !feed.Opts.DateFilterEnd.IsEmpty()) {
 		feed.filterServices()
 	}
 
-	if e == nil && feed.opts.DropSingleStopTrips {
+	if e == nil && feed.Opts.DropSingleStopTrips {
 		for _, t := range feed.Trips {
 			if len(t.StopTimes) < 2 {
 				feed.DeleteTrip(t.Id)
@@ -173,11 +173,11 @@ func (feed *Feed) PrefixParseReader(reader io.Reader, prefix string) error {
 		feed.curFileHandle = nil
 	}
 
-	if !feed.opts.DateFilterStart.IsEmpty() || !feed.opts.DateFilterEnd.IsEmpty() {
+	if !feed.Opts.DateFilterStart.IsEmpty() || !feed.Opts.DateFilterEnd.IsEmpty() {
 		feed.filterServices()
 	}
 
-	if feed.opts.DropSingleStopTrips {
+	if feed.Opts.DropSingleStopTrips {
 		for _, t := range feed.Trips {
 			if len(t.StopTimes) < 2 {
 				feed.DeleteTrip(t.Id)
@@ -189,7 +189,7 @@ func (feed *Feed) PrefixParseReader(reader io.Reader, prefix string) error {
 }
 
 func (feed *Feed) parseAgenciesReader(file io.Reader, prefix string, fallbackUrl string) (err error) {
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -212,7 +212,7 @@ func (feed *Feed) parseAgenciesReader(file io.Reader, prefix string, fallbackUrl
 
 	addFlds := make([]int, 0)
 
-	if feed.opts.KeepAddFlds {
+	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
 	for record = reader.ParseCsvLine(); record != nil; record = reader.ParseCsvLine() {
@@ -237,7 +237,7 @@ func (feed *Feed) parseAgenciesReader(file io.Reader, prefix string, fallbackUrl
 		}
 
 		if e != nil {
-			if feed.opts.DropErroneous {
+			if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedAgencies++
 				feed.warn(e)
 				continue
@@ -273,7 +273,7 @@ func (feed *Feed) parseAgenciesReader(file io.Reader, prefix string, fallbackUrl
 }
 
 func (feed *Feed) parseStopsReader(file io.Reader, prefix string, geofiltered map[string]struct{}) (err error) {
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -302,7 +302,7 @@ func (feed *Feed) parseStopsReader(file io.Reader, prefix string, geofiltered ma
 
 	addFlds := make([]int, 0)
 
-	if feed.opts.KeepAddFlds {
+	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
 
@@ -315,7 +315,7 @@ func (feed *Feed) parseStopsReader(file io.Reader, prefix string, geofiltered ma
 			}
 		}
 		if e != nil {
-			if feed.opts.DropErroneous {
+			if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedStops++
 				feed.warn(e)
 				continue
@@ -326,7 +326,7 @@ func (feed *Feed) parseStopsReader(file io.Reader, prefix string, geofiltered ma
 
 		// check if any defined PolygonFilter contains the stop
 		contains := true
-		for _, poly := range feed.opts.PolygonFilter {
+		for _, poly := range feed.Opts.PolygonFilter {
 			contains = false
 			if poly.PolyContains(float64(stop.Lon), float64(stop.Lat)) {
 				contains = true
@@ -369,11 +369,11 @@ func (feed *Feed) parseStopsReader(file io.Reader, prefix string, geofiltered ma
 			if wasFiltered && feed.Stops[id].Location_type < 2 {
 				// continue, the default value "nil" has already be written above
 				continue
-			} else if feed.opts.UseDefValueOnError && feed.Stops[id].Location_type < 2 {
+			} else if feed.Opts.UseDefValueOnError && feed.Stops[id].Location_type < 2 {
 				// continue, the default value "nil" has already be written above
 				feed.warn(locErr)
 				continue
-			} else if feed.opts.DropErroneous {
+			} else if feed.Opts.DropErroneous {
 				// delete the erroneous entry
 				delete(feed.Stops, id)
 				feed.ErrorStats.DroppedStops++
@@ -386,11 +386,11 @@ func (feed *Feed) parseStopsReader(file io.Reader, prefix string, geofiltered ma
 
 		if (feed.Stops[id].Location_type == 0 || feed.Stops[id].Location_type == 2 || feed.Stops[id].Location_type == 3) && pstop.Location_type != 1 {
 			locErr := fmt.Errorf("(for stop id %s) Station with id %s has location_type=%d, cannot use as parent station here for stop with location_type=%d (must be 1)", id, pid, pstop.Location_type, feed.Stops[id].Location_type)
-			if feed.opts.UseDefValueOnError && !(feed.Stops[id].Location_type == 2 || feed.Stops[id].Location_type == 3) {
+			if feed.Opts.UseDefValueOnError && !(feed.Stops[id].Location_type == 2 || feed.Stops[id].Location_type == 3) {
 				// continue, the default value "nil" has already be written above
 				feed.warn(locErr)
 				continue
-			} else if feed.opts.DropErroneous {
+			} else if feed.Opts.DropErroneous {
 				// delete the erroneous entry
 				delete(feed.Stops, id)
 				feed.ErrorStats.DroppedStops++
@@ -403,7 +403,7 @@ func (feed *Feed) parseStopsReader(file io.Reader, prefix string, geofiltered ma
 
 		if feed.Stops[id].Location_type == 4 && pstop.Location_type != 0 {
 			locErr := fmt.Errorf("(for stop id %s) Station with id %s has location_type=%d, cannot use as parent station here for stop with location_type=4 (boarding area), which expects a parent station with location_type=0 (stop/platform)", id, pid, pstop.Location_type)
-			if feed.opts.DropErroneous {
+			if feed.Opts.DropErroneous {
 				// delete the erroneous entry
 				delete(feed.Stops, id)
 				feed.ErrorStats.DroppedStops++
@@ -421,7 +421,7 @@ func (feed *Feed) parseStopsReader(file io.Reader, prefix string, geofiltered ma
 }
 
 func (feed *Feed) parseRoutesReader(file io.Reader, prefix string, filtered map[string]struct{}) (err error) {
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -448,7 +448,7 @@ func (feed *Feed) parseRoutesReader(file io.Reader, prefix string, filtered map[
 
 	addFlds := make([]int, 0)
 
-	if feed.opts.KeepAddFlds {
+	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
 
@@ -460,7 +460,7 @@ func (feed *Feed) parseRoutesReader(file io.Reader, prefix string, filtered map[
 			}
 		}
 		if e != nil {
-			if feed.opts.DropErroneous {
+			if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedRoutes++
 				feed.warn(e)
 				continue
@@ -469,29 +469,29 @@ func (feed *Feed) parseRoutesReader(file io.Reader, prefix string, filtered map[
 			}
 		}
 
-		if feed.opts.UseStandardRouteTypes {
+		if feed.Opts.UseStandardRouteTypes {
 			route.Type = gtfs.GetTypeFromExtended(route.Type)
 		}
 
-		if feed.opts.UseGoogleSupportedRouteTypes {
+		if feed.Opts.UseGoogleSupportedRouteTypes {
 			route.Type = gtfs.GetSupportedExtendedTypeFromExtended(route.Type)
 		}
 
-		if len(feed.opts.MOTFilter) != 0 {
-			if _, ok := feed.opts.MOTFilter[route.Type]; !ok {
+		if len(feed.Opts.MOTFilter) != 0 {
+			if _, ok := feed.Opts.MOTFilter[route.Type]; !ok {
 				filtered[route.Id] = struct{}{}
 				continue
 			}
 		}
 
-		if len(feed.opts.MOTFilterNeg) != 0 {
-			if _, ok := feed.opts.MOTFilterNeg[route.Type]; ok {
+		if len(feed.Opts.MOTFilterNeg) != 0 {
+			if _, ok := feed.Opts.MOTFilterNeg[route.Type]; ok {
 				filtered[route.Id] = struct{}{}
 				continue
 			}
 		}
 
-		if feed.opts.DryRun {
+		if feed.Opts.DryRun {
 			feed.Routes[route.Id] = route
 		} else {
 			feed.Routes[route.Id] = route
@@ -514,7 +514,7 @@ func (feed *Feed) parseRoutesReader(file io.Reader, prefix string, filtered map[
 }
 
 func (feed *Feed) parseCalendarReader(file io.Reader, prefix string) (err error) {
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -541,7 +541,7 @@ func (feed *Feed) parseCalendarReader(file io.Reader, prefix string) (err error)
 		service, e := createServiceFromCalendar(record, flds, feed, prefix)
 
 		if e != nil {
-			if feed.opts.DropErroneous {
+			if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedServices++
 				feed.warn(e)
 				continue
@@ -552,26 +552,26 @@ func (feed *Feed) parseCalendarReader(file io.Reader, prefix string) (err error)
 
 		// if service was parsed in-place, nil was returned
 		if service != nil {
-			if feed.opts.DryRun {
+			if feed.Opts.DryRun {
 				feed.Services[service.Id()] = nil
 			} else {
 				feed.Services[service.Id()] = service
 
 				// check if service is completely out of range
-				if !feed.opts.DateFilterStart.IsEmpty() && service.End_date().GetTime().Before(feed.opts.DateFilterStart.GetTime()) || !feed.opts.DateFilterEnd.IsEmpty() && service.Start_date().GetTime().After(feed.opts.DateFilterEnd.GetTime()) {
+				if !feed.Opts.DateFilterStart.IsEmpty() && service.End_date().GetTime().Before(feed.Opts.DateFilterStart.GetTime()) || !feed.Opts.DateFilterEnd.IsEmpty() && service.Start_date().GetTime().After(feed.Opts.DateFilterEnd.GetTime()) {
 					service.SetRawDaymap(0)
 				} else {
 					// we overlap, there are now two cases:
 
 					// 1. A start date is defined, and the service starts before the start time. Set the start time to the new start time
-					if !feed.opts.DateFilterStart.IsEmpty() && service.Start_date().GetTime().Before(feed.opts.DateFilterStart.GetTime()) {
-						service.SetStart_date(feed.opts.DateFilterStart)
+					if !feed.Opts.DateFilterStart.IsEmpty() && service.Start_date().GetTime().Before(feed.Opts.DateFilterStart.GetTime()) {
+						service.SetStart_date(feed.Opts.DateFilterStart)
 						// note: because of the check above, End_date is guaranteed to >= DateFilterStart, so our service remains valid
 					}
 
 					// 2. An end date is defined, and the service ends after the start time. Set the end  time to the new end time
-					if !feed.opts.DateFilterEnd.IsEmpty() && service.End_date().GetTime().After(feed.opts.DateFilterEnd.GetTime()) {
-						service.SetEnd_date(feed.opts.DateFilterEnd)
+					if !feed.Opts.DateFilterEnd.IsEmpty() && service.End_date().GetTime().After(feed.Opts.DateFilterEnd.GetTime()) {
+						service.SetEnd_date(feed.Opts.DateFilterEnd)
 						// note: because of the check above, Start_date is guaranteed to <= DateFilterEnd, so our service remains valid
 					}
 				}
@@ -585,7 +585,7 @@ func (feed *Feed) parseCalendarReader(file io.Reader, prefix string) (err error)
 }
 
 func (feed *Feed) parseCalendarDatesReader(file io.Reader, prefix string) (err error) {
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -602,10 +602,10 @@ func (feed *Feed) parseCalendarDatesReader(file io.Reader, prefix string) (err e
 	}
 
 	for record = reader.ParseCsvLine(); record != nil; record = reader.ParseCsvLine() {
-		service, e := createServiceFromCalendarDates(record, flds, feed, feed.opts.DateFilterStart, feed.opts.DateFilterEnd, prefix)
+		service, e := createServiceFromCalendarDates(record, flds, feed, feed.Opts.DateFilterStart, feed.Opts.DateFilterEnd, prefix)
 
 		if e != nil {
-			if feed.opts.DropErroneous {
+			if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedServices++
 				feed.warn(e)
 				continue
@@ -616,7 +616,7 @@ func (feed *Feed) parseCalendarDatesReader(file io.Reader, prefix string) (err e
 
 		// if service was parsed in-place, nil was returned
 		if service != nil {
-			if feed.opts.DryRun {
+			if feed.Opts.DryRun {
 				feed.Services[service.Id()] = nil
 			} else {
 				feed.Services[service.Id()] = service
@@ -630,7 +630,7 @@ func (feed *Feed) parseCalendarDatesReader(file io.Reader, prefix string) (err e
 }
 
 func (feed *Feed) parseTripsReader(file io.Reader, prefix string, filteredRoutes map[string]struct{}, filteredTrips map[string]struct{}) (err error) {
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -655,7 +655,7 @@ func (feed *Feed) parseTripsReader(file io.Reader, prefix string, filteredRoutes
 
 	addFlds := make([]int, 0)
 
-	if feed.opts.KeepAddFlds {
+	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
 
@@ -683,7 +683,7 @@ func (feed *Feed) parseTripsReader(file io.Reader, prefix string, filteredRoutes
 			if wasFiltered {
 				filteredTrips[routeNotFoundErr.PayloadId()] = struct{}{}
 				continue
-			} else if feed.opts.DropErroneous {
+			} else if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedTrips++
 				feed.warn(e)
 				continue
@@ -710,11 +710,11 @@ func (feed *Feed) parseTripsReader(file io.Reader, prefix string, filteredRoutes
 }
 
 func (feed *Feed) reserveShapesReader(file io.Reader, prefix string) (err error) {
-	if feed.opts.DropShapes {
+	if feed.Opts.DropShapes {
 		return
 	}
 
-	reader := NewCsvParser(file, feed.opts.DropErroneous, feed.opts.AssumeCleanCsv && !feed.opts.KeepAddFlds)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, feed.Opts.AssumeCleanCsv && !feed.Opts.KeepAddFlds)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -735,7 +735,7 @@ func (feed *Feed) reserveShapesReader(file io.Reader, prefix string) (err error)
 	for record = reader.ParseCsvLine(); record != nil; record = reader.ParseCsvLine() {
 		e := reserveShapePoint(record, flds, feed, prefix)
 		if e != nil {
-			if feed.opts.DropErroneous {
+			if feed.Opts.DropErroneous {
 				continue
 			} else {
 				panic(e)
@@ -747,10 +747,10 @@ func (feed *Feed) reserveShapesReader(file io.Reader, prefix string) (err error)
 }
 
 func (feed *Feed) parseShapesReader(file io.Reader, prefix string) (err error) {
-	if feed.opts.DropShapes {
+	if feed.Opts.DropShapes {
 		return
 	}
-	reader := NewCsvParser(file, feed.opts.DropErroneous, feed.opts.AssumeCleanCsv && !feed.opts.KeepAddFlds)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, feed.Opts.AssumeCleanCsv && !feed.Opts.KeepAddFlds)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -770,7 +770,7 @@ func (feed *Feed) parseShapesReader(file io.Reader, prefix string) (err error) {
 
 	addFlds := make([]int, 0)
 
-	if feed.opts.KeepAddFlds {
+	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
 
@@ -782,7 +782,7 @@ func (feed *Feed) parseShapesReader(file io.Reader, prefix string) (err error) {
 		shape, sp, e := createShapePoint(record, flds, feed, prefix)
 
 		if e != nil {
-			if feed.opts.DropErroneous {
+			if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedShapes++
 				feed.warn(e)
 				continue
@@ -812,7 +812,7 @@ func (feed *Feed) parseShapesReader(file io.Reader, prefix string) (err error) {
 		for id, shape := range feed.Shapes {
 			if len(shape.Points) == 0 {
 				loce := fmt.Errorf("shape #%s has no points", id)
-				if feed.opts.DropErroneous || len(feed.opts.PolygonFilter) > 0 {
+				if feed.Opts.DropErroneous || len(feed.Opts.PolygonFilter) > 0 {
 					// dont warn here, because this can only happen if a shape point
 					// has been deleted before
 					delete(feed.Shapes, id)
@@ -822,13 +822,13 @@ func (feed *Feed) parseShapesReader(file io.Reader, prefix string) (err error) {
 				}
 			}
 			sort.Sort(shape.Points)
-			e = feed.checkShapeMeasure(shape, &feed.opts)
+			e = feed.checkShapeMeasure(shape, &feed.Opts)
 			feed.NumShpPoints += len(shape.Points)
 			if e != nil {
 				break
 			}
 		}
-		if feed.opts.DryRun {
+		if feed.Opts.DryRun {
 			// clear space
 			for id := range feed.Shapes {
 				feed.Shapes[id] = nil
@@ -840,7 +840,7 @@ func (feed *Feed) parseShapesReader(file io.Reader, prefix string) (err error) {
 }
 
 func (feed *Feed) reserveStopTimesReader(file io.Reader, prefix string) (err error) {
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 	file2 := file
 
 	defer func() {
@@ -870,7 +870,7 @@ func (feed *Feed) reserveStopTimesReader(file io.Reader, prefix string) (err err
 		return errors.New("could not open required file stop_times.txt")
 	}
 
-	reader = NewCsvParser(file2, feed.opts.DropErroneous, feed.opts.AssumeCleanCsv && flds.stopHeadsign < 0 && !feed.opts.KeepAddFlds)
+	reader = NewCsvParser(file2, feed.Opts.DropErroneous, feed.Opts.AssumeCleanCsv && flds.stopHeadsign < 0 && !feed.Opts.KeepAddFlds)
 
 	for record = reader.ParseCsvLine(); record != nil; record = reader.ParseCsvLine() {
 		reserveStopTime(record, flds, feed, prefix)
@@ -880,7 +880,7 @@ func (feed *Feed) reserveStopTimesReader(file io.Reader, prefix string) (err err
 }
 
 func (feed *Feed) parseStopTimesReader(file io.Reader, prefix string, geofiltered map[string]struct{}, filteredTrips map[string]struct{}) (err error) {
-	reader := NewCsvParser(file, feed.opts.DropErroneous, feed.opts.AssumeCleanCsv && !feed.opts.KeepAddFlds)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, feed.Opts.AssumeCleanCsv && !feed.Opts.KeepAddFlds)
 	file2 := file
 
 	defer func() {
@@ -908,7 +908,7 @@ func (feed *Feed) parseStopTimesReader(file io.Reader, prefix string, geofiltere
 
 	addFlds := make([]int, 0)
 
-	if feed.opts.KeepAddFlds {
+	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
 
@@ -916,7 +916,7 @@ func (feed *Feed) parseStopTimesReader(file io.Reader, prefix string, geofiltere
 		return errors.New("could not open required file stop_times.txt")
 	}
 
-	reader = NewCsvParser(file2, feed.opts.DropErroneous, feed.opts.AssumeCleanCsv && flds.stopHeadsign < 0)
+	reader = NewCsvParser(file2, feed.Opts.DropErroneous, feed.Opts.AssumeCleanCsv && flds.stopHeadsign < 0)
 
 	i := 0
 
@@ -939,7 +939,7 @@ func (feed *Feed) parseStopTimesReader(file io.Reader, prefix string, geofiltere
 
 			if wasFiltered {
 				continue
-			} else if feed.opts.DropErroneous {
+			} else if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedStopTimes++
 				feed.warn(e)
 				continue
@@ -968,7 +968,7 @@ func (feed *Feed) parseStopTimesReader(file io.Reader, prefix string, geofiltere
 		// sort stoptimes in trips
 		for _, trip := range feed.Trips {
 			sort.Sort(trip.StopTimes)
-			e = feed.checkStopTimeMeasure(trip, &feed.opts)
+			e = feed.checkStopTimeMeasure(trip, &feed.Opts)
 			feed.NumStopTimes += len(trip.StopTimes)
 			if e != nil {
 				break
@@ -980,7 +980,7 @@ func (feed *Feed) parseStopTimesReader(file io.Reader, prefix string, geofiltere
 }
 
 func (feed *Feed) parseFrequenciesReader(file io.Reader, prefix string, filteredTrips map[string]struct{}) (err error) {
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -1000,7 +1000,7 @@ func (feed *Feed) parseFrequenciesReader(file io.Reader, prefix string, filtered
 
 	addFlds := make([]int, 0)
 
-	if feed.opts.KeepAddFlds {
+	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
 
@@ -1015,7 +1015,7 @@ func (feed *Feed) parseFrequenciesReader(file io.Reader, prefix string, filtered
 
 			if wasFiltered {
 				continue
-			} else if feed.opts.DropErroneous {
+			} else if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedFrequencies++
 				feed.warn(e)
 				continue
@@ -1044,7 +1044,7 @@ func (feed *Feed) parseFrequenciesReader(file io.Reader, prefix string, filtered
 }
 
 func (feed *Feed) parseFareAttributesReader(file io.Reader, prefix string) (err error) {
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -1066,14 +1066,14 @@ func (feed *Feed) parseFareAttributesReader(file io.Reader, prefix string) (err 
 
 	addFlds := make([]int, 0)
 
-	if feed.opts.KeepAddFlds {
+	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
 
 	for record = reader.ParseCsvLine(); record != nil; record = reader.ParseCsvLine() {
 		fa, e := createFareAttribute(record, flds, feed, prefix)
 		if e != nil {
-			if feed.opts.DropErroneous {
+			if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedFareAttributes++
 				feed.warn(e)
 				continue
@@ -1100,7 +1100,7 @@ func (feed *Feed) parseFareAttributesReader(file io.Reader, prefix string) (err 
 }
 
 func (feed *Feed) parseFareAttributeRulesReader(file io.Reader, prefix string, filteredRoutes map[string]struct{}) (err error) {
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -1120,7 +1120,7 @@ func (feed *Feed) parseFareAttributeRulesReader(file io.Reader, prefix string, f
 
 	addFlds := make([]int, 0)
 
-	if feed.opts.KeepAddFlds {
+	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
 
@@ -1135,7 +1135,7 @@ func (feed *Feed) parseFareAttributeRulesReader(file io.Reader, prefix string, f
 
 			if wasFiltered {
 				continue
-			} else if feed.opts.DropErroneous {
+			} else if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedFareAttributeRules++
 				feed.warn(e)
 				continue
@@ -1165,7 +1165,7 @@ func (feed *Feed) parseFareAttributeRulesReader(file io.Reader, prefix string, f
 }
 
 func (feed *Feed) parseTransfersReader(file io.Reader, prefix string, geofiltered map[string]struct{}) (err error) {
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -1188,7 +1188,7 @@ func (feed *Feed) parseTransfersReader(file io.Reader, prefix string, geofiltere
 
 	addFlds := make([]int, 0)
 
-	if feed.opts.KeepAddFlds {
+	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
 	for record = reader.ParseCsvLine(); record != nil; record = reader.ParseCsvLine() {
@@ -1207,7 +1207,7 @@ func (feed *Feed) parseTransfersReader(file io.Reader, prefix string, geofiltere
 
 			if wasFiltered {
 				continue
-			} else if feed.opts.DropErroneous {
+			} else if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedTransfers++
 				feed.warn(e)
 				continue
@@ -1218,7 +1218,7 @@ func (feed *Feed) parseTransfersReader(file io.Reader, prefix string, geofiltere
 
 		feed.Transfers[tk] = tv
 
-		if !feed.opts.DryRun {
+		if !feed.Opts.DryRun {
 			// add additional CSV fields
 			for _, i := range addFlds {
 				if i < len(record) {
@@ -1238,7 +1238,7 @@ func (feed *Feed) parseTransfersReader(file io.Reader, prefix string, geofiltere
 }
 
 func (feed *Feed) parsePathwaysReader(file io.Reader, prefix string, geofiltered map[string]struct{}) (err error) {
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -1265,7 +1265,7 @@ func (feed *Feed) parsePathwaysReader(file io.Reader, prefix string, geofiltered
 
 	addFlds := make([]int, 0)
 
-	if feed.opts.KeepAddFlds {
+	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
 
@@ -1285,7 +1285,7 @@ func (feed *Feed) parsePathwaysReader(file io.Reader, prefix string, geofiltered
 
 			if wasFiltered {
 				continue
-			} else if feed.opts.DropErroneous {
+			} else if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedPathways++
 				feed.warn(e)
 				continue
@@ -1312,7 +1312,7 @@ func (feed *Feed) parsePathwaysReader(file io.Reader, prefix string, geofiltered
 }
 
 func (feed *Feed) parseAttributionsReader(file io.Reader, prefix string, filteredRoutes map[string]struct{}, filteredTrips map[string]struct{}) (err error) {
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -1340,7 +1340,7 @@ func (feed *Feed) parseAttributionsReader(file io.Reader, prefix string, filtere
 
 	addFlds := make([]int, 0)
 
-	if feed.opts.KeepAddFlds {
+	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
 
@@ -1372,7 +1372,7 @@ func (feed *Feed) parseAttributionsReader(file io.Reader, prefix string, filtere
 
 			if wasFiltered {
 				continue
-			} else if feed.opts.DropErroneous {
+			} else if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedAttributions++
 				feed.warn(e)
 				continue
@@ -1414,7 +1414,7 @@ func (feed *Feed) parseAttributionsReader(file io.Reader, prefix string, filtere
 }
 
 func (feed *Feed) parseLevelsReader(file io.Reader, idprefix string) (err error) {
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -1432,7 +1432,7 @@ func (feed *Feed) parseLevelsReader(file io.Reader, idprefix string) (err error)
 
 	addFlds := make([]int, 0)
 
-	if feed.opts.KeepAddFlds {
+	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
 	for record = reader.ParseCsvLine(); record != nil; record = reader.ParseCsvLine() {
@@ -1444,7 +1444,7 @@ func (feed *Feed) parseLevelsReader(file io.Reader, idprefix string) (err error)
 		}
 
 		if e != nil {
-			if feed.opts.DropErroneous {
+			if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedLevels++
 				feed.warn(e)
 				continue
@@ -1471,7 +1471,7 @@ func (feed *Feed) parseLevelsReader(file io.Reader, idprefix string) (err error)
 }
 
 func (feed *Feed) parseFeedInfosReader(file io.Reader) (err error) {
-	reader := NewCsvParser(file, feed.opts.DropErroneous, false)
+	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -1494,14 +1494,14 @@ func (feed *Feed) parseFeedInfosReader(file io.Reader) (err error) {
 
 	addFlds := make([]int, 0)
 
-	if feed.opts.KeepAddFlds {
+	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
 
 	for record = reader.ParseCsvLine(); record != nil; record = reader.ParseCsvLine() {
 		fi, e := createFeedInfo(record, flds, feed)
 		if e != nil {
-			if feed.opts.DropErroneous {
+			if feed.Opts.DropErroneous {
 				feed.ErrorStats.DroppedFeedInfos++
 				feed.warn(e)
 				continue
@@ -1509,7 +1509,7 @@ func (feed *Feed) parseFeedInfosReader(file io.Reader) (err error) {
 				panic(e)
 			}
 		}
-		if !feed.opts.DryRun {
+		if !feed.Opts.DryRun {
 			for _, i := range addFlds {
 				if i < len(record) {
 					if _, ok := feed.FeedInfosAddFlds[reader.header[i]]; !ok {

--- a/feed_reader.go
+++ b/feed_reader.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	url "net/url"
-	"os"
 	"sort"
 	"strings"
 
@@ -28,9 +27,6 @@ func (feed *Feed) PrefixParseReader(reader io.Reader, prefix string) error {
 	if err != nil {
 		return fmt.Errorf("reading gtfs archive: %w", err)
 	}
-
-	fmt.Println("bytes letti dal reader:", len(data))
-	os.WriteFile("/tmp/debug_gtfs.zip", data, 0644)
 
 	zip_reader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
 	if err != nil {
@@ -888,8 +884,12 @@ func (feed *Feed) reserveStopTimesReader(file io.Reader, prefix string) (err err
 }
 
 func (feed *Feed) parseStopTimesReader(file io.Reader, prefix string, geofiltered map[string]struct{}, filteredTrips map[string]struct{}) (err error) {
-	reader := NewCsvParser(file, feed.Opts.DropErroneous, feed.Opts.AssumeCleanCsv && !feed.Opts.KeepAddFlds)
-	file2 := file
+	data, e := io.ReadAll(file)
+    if e != nil {
+        return errors.New("could not read stop_times.txt")
+    }
+
+	reader := NewCsvParser(bytes.NewReader(data), feed.Opts.DropErroneous, feed.Opts.AssumeCleanCsv && !feed.Opts.KeepAddFlds)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -897,7 +897,6 @@ func (feed *Feed) parseStopTimesReader(file io.Reader, prefix string, geofiltere
 		}
 	}()
 
-	var e error
 	var record []string
 	flds := StopTimeFields{
 		tripId:            reader.headeridx.GetFldId("trip_id", -1),
@@ -920,11 +919,7 @@ func (feed *Feed) parseStopTimesReader(file io.Reader, prefix string, geofiltere
 		addFlds = addiFields(reader.header, flds)
 	}
 
-	if e != nil {
-		return errors.New("could not open required file stop_times.txt")
-	}
-
-	reader = NewCsvParser(file2, feed.Opts.DropErroneous, feed.Opts.AssumeCleanCsv && flds.stopHeadsign < 0)
+	reader = NewCsvParser(bytes.NewReader(data), feed.Opts.DropErroneous, feed.Opts.AssumeCleanCsv && flds.stopHeadsign < 0)
 
 	i := 0
 

--- a/feed_reader.go
+++ b/feed_reader.go
@@ -755,7 +755,13 @@ func (feed *Feed) parseShapesReader(file io.Reader, prefix string) (err error) {
 	if feed.Opts.DropShapes {
 		return
 	}
-	reader := NewCsvParser(file, feed.Opts.DropErroneous, feed.Opts.AssumeCleanCsv && !feed.Opts.KeepAddFlds)
+
+	data, e := io.ReadAll(file)
+    if e != nil {
+        return errors.New("could not read shapes.txt")
+    }
+
+    reader := NewCsvParser(bytes.NewReader(data), feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -763,7 +769,6 @@ func (feed *Feed) parseShapesReader(file io.Reader, prefix string) (err error) {
 		}
 	}()
 
-	var e error
 	var record []string
 	flds := ShapeFields{
 		shapeId:           reader.headeridx.GetFldId("shape_id", -1),
@@ -778,6 +783,8 @@ func (feed *Feed) parseShapesReader(file io.Reader, prefix string) (err error) {
 	if feed.Opts.KeepAddFlds {
 		addFlds = addiFields(reader.header, flds)
 	}
+
+    reader = NewCsvParser(bytes.NewReader(data), feed.Opts.DropErroneous, feed.Opts.AssumeCleanCsv && !feed.Opts.KeepAddFlds)
 
 	i := 0
 

--- a/feed_reader.go
+++ b/feed_reader.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	url "net/url"
+	"os"
 	"sort"
 	"strings"
 
@@ -27,6 +28,9 @@ func (feed *Feed) PrefixParseReader(reader io.Reader, prefix string) error {
 	if err != nil {
 		return fmt.Errorf("reading gtfs archive: %w", err)
 	}
+
+	fmt.Println("bytes letti dal reader:", len(data))
+	os.WriteFile("/tmp/debug_gtfs.zip", data, 0644)
 
 	zip_reader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
 	if err != nil {

--- a/feed_reader.go
+++ b/feed_reader.go
@@ -714,7 +714,12 @@ func (feed *Feed) reserveShapesReader(file io.Reader, prefix string) (err error)
 		return
 	}
 
-	reader := NewCsvParser(file, feed.Opts.DropErroneous, feed.Opts.AssumeCleanCsv && !feed.Opts.KeepAddFlds)
+	data, e := io.ReadAll(file)
+    if e != nil {
+        return errors.New("could not read shapes.txt")
+    }
+
+    reader := NewCsvParser(bytes.NewReader(data), feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -722,7 +727,6 @@ func (feed *Feed) reserveShapesReader(file io.Reader, prefix string) (err error)
 		}
 	}()
 
-	var e error
 	var record []string
 	flds := ShapeFields{
 		shapeId:           reader.headeridx.GetFldId("shape_id", -1),
@@ -732,6 +736,7 @@ func (feed *Feed) reserveShapesReader(file io.Reader, prefix string) (err error)
 		shapePtSequence:   reader.headeridx.GetFldId("shape_pt_sequence", -5),
 	}
 
+    reader = NewCsvParser(bytes.NewReader(data), feed.Opts.DropErroneous, feed.Opts.AssumeCleanCsv && !feed.Opts.KeepAddFlds)
 	for record = reader.ParseCsvLine(); record != nil; record = reader.ParseCsvLine() {
 		e := reserveShapePoint(record, flds, feed, prefix)
 		if e != nil {
@@ -840,8 +845,12 @@ func (feed *Feed) parseShapesReader(file io.Reader, prefix string) (err error) {
 }
 
 func (feed *Feed) reserveStopTimesReader(file io.Reader, prefix string) (err error) {
-	reader := NewCsvParser(file, feed.Opts.DropErroneous, false)
-	file2 := file
+	data, e := io.ReadAll(file)
+    if e != nil {
+        return errors.New("could not read stop_times.txt")
+    }
+
+	reader := NewCsvParser(bytes.NewReader(data), feed.Opts.DropErroneous, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -849,7 +858,6 @@ func (feed *Feed) reserveStopTimesReader(file io.Reader, prefix string) (err err
 		}
 	}()
 
-	var e error
 	var record []string
 	flds := StopTimeFields{
 		tripId:            reader.headeridx.GetFldId("trip_id", -1),
@@ -866,15 +874,11 @@ func (feed *Feed) reserveStopTimesReader(file io.Reader, prefix string) (err err
 		timepoint:         reader.headeridx.GetFldId("timepoint", -12),
 	}
 
-	if e != nil {
-		return errors.New("could not open required file stop_times.txt")
-	}
-
-	reader = NewCsvParser(file2, feed.Opts.DropErroneous, feed.Opts.AssumeCleanCsv && flds.stopHeadsign < 0 && !feed.Opts.KeepAddFlds)
-
+	reader = NewCsvParser(bytes.NewReader(data), feed.Opts.DropErroneous, feed.Opts.AssumeCleanCsv && flds.stopHeadsign < 0 && !feed.Opts.KeepAddFlds)
+    
 	for record = reader.ParseCsvLine(); record != nil; record = reader.ParseCsvLine() {
-		reserveStopTime(record, flds, feed, prefix)
-	}
+        reserveStopTime(record, flds, feed, prefix)
+    }
 
 	return e
 }

--- a/feed_test.go
+++ b/feed_test.go
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a GPL v2
 // license that can be found in the LICENSE file
 
-package gtfsparser
+package gtfsparserwr
 
 import (
 	// "github.com/public-transport/gtfsparser/gtfs"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/public-transport/gtfsparser
+module github.com/Leocraft1/gtfsparser-with-reader
 
 go 1.21
 

--- a/gtfs/route.go
+++ b/gtfs/route.go
@@ -336,6 +336,4 @@ func GetSupportedExtendedTypeFromExtended(t int16) int16 {
 	default:
 		return t
 	}
-
-	return t // fallback
 }

--- a/gtfs/service.go
+++ b/gtfs/service.go
@@ -102,6 +102,10 @@ func (d Date) Month() uint8 {
 	return d.month
 }
 
+func (d *Date) SetMonth(month uint8) {
+	d.month = month
+}
+
 func (d Date) Year() uint16 {
 	return uint16(d.year) + 1900
 }

--- a/gtfs/stoptimes.go
+++ b/gtfs/stoptimes.go
@@ -176,6 +176,12 @@ func (a Time) GetLocationTime(d Date, agency *Agency) time.Time {
 	return time.Date(int(d.Year()), time.Month(d.Month()), int(d.Day()), int(a.Hour), int(a.Minute), int(a.Second), 0, &agency.Timezone)
 }
 
+// GetTime returns the time.Time of the gtfs time on a certain for Europe timezone
+func (a Time) GetTime() time.Time {
+	location, _:= time.LoadLocation("Europe/Rome")
+	return time.Date(2000, 1, 1, int(a.Hour), int(a.Minute), int(a.Second), 0, location)
+}
+
 // HasDistanceTraveled returns true if this ShapePoint has a measurement
 func (s StopTime) HasDistanceTraveled() bool {
 	return !math.IsNaN(float64(s.Shape_dist_traveled()))

--- a/mapping.go
+++ b/mapping.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/public-transport/gtfsparser/gtfs"
+	"github.com/Leocraft1/gtfsparser-with-reader/gtfs"
 	"github.com/valyala/fastjson/fastfloat"
 	"golang.org/x/text/language"
 )

--- a/mapping.go
+++ b/mapping.go
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a GPL v2
 // license that can be found in the LICENSE file
 
-package gtfsparser
+package gtfsparserwr
 
 import (
 	hex "encoding/hex"

--- a/mapping.go
+++ b/mapping.go
@@ -689,7 +689,7 @@ func createTranslation(r []string, flds TranslationFields, feed *Feed, prefix st
 
 	tableName := getString(flds.tableName, r, flds.FldName(flds.tableName), true, true, "")
 
-	if !feed.opts.DryRun && !(tableName == "agency" || tableName == "stops" || tableName == "routes" || tableName == "trips" || tableName == "stop_times" || tableName == "feed_info" || tableName == "pathways" || tableName == "attributions" || tableName == "levels") {
+	if !feed.Opts.DryRun && !(tableName == "agency" || tableName == "stops" || tableName == "routes" || tableName == "trips" || tableName == "stop_times" || tableName == "feed_info" || tableName == "pathways" || tableName == "attributions" || tableName == "levels") {
 		panic(fmt.Errorf("table_name must be one of: 'agency', 'stops', 'routes', 'trips', 'stop_times', 'feed_info', 'pathways', 'attributions', 'levels' (found '%s')", tableName))
 	}
 
@@ -751,14 +751,14 @@ func createAttribution(r []string, flds AttributionFields, feed *Feed, prefix st
 	a := new(gtfs.Attribution)
 
 	a.Id = prefix + getString(flds.attributionId, r, flds.FldName(flds.attributionId), false, false, "")
-	a.Organization_name = getString(flds.organizationName, r, flds.FldName(flds.organizationName), true, true, feed.opts.EmptyStringRepl)
-	a.Is_producer = getBool(flds.isProducer, r, flds.FldName(flds.isProducer), false, false, feed.opts.UseDefValueOnError, feed)
-	a.Is_operator = getBool(flds.isOperator, r, flds.FldName(flds.isOperator), false, false, feed.opts.UseDefValueOnError, feed)
-	a.Is_authority = getBool(flds.isAuthority, r, flds.FldName(flds.isAuthority), false, false, feed.opts.UseDefValueOnError, feed)
+	a.Organization_name = getString(flds.organizationName, r, flds.FldName(flds.organizationName), true, true, feed.Opts.EmptyStringRepl)
+	a.Is_producer = getBool(flds.isProducer, r, flds.FldName(flds.isProducer), false, false, feed.Opts.UseDefValueOnError, feed)
+	a.Is_operator = getBool(flds.isOperator, r, flds.FldName(flds.isOperator), false, false, feed.Opts.UseDefValueOnError, feed)
+	a.Is_authority = getBool(flds.isAuthority, r, flds.FldName(flds.isAuthority), false, false, feed.Opts.UseDefValueOnError, feed)
 
-	a.Url = getURL(flds.attributionUrl, r, flds, false, feed.opts.UseDefValueOnError, feed)
-	a.Email = getMail(flds.attributionEmail, r, flds, false, feed.opts.UseDefValueOnError, feed)
-	a.Phone = getString(flds.attributionPhone, r, flds.FldName(flds.attributionPhone), false, false, feed.opts.EmptyStringRepl)
+	a.Url = getURL(flds.attributionUrl, r, flds, false, feed.Opts.UseDefValueOnError, feed)
+	a.Email = getMail(flds.attributionEmail, r, flds, false, feed.Opts.UseDefValueOnError, feed)
+	a.Phone = getString(flds.attributionPhone, r, flds.FldName(flds.attributionPhone), false, false, feed.Opts.EmptyStringRepl)
 
 	routeId := getString(flds.routeId, r, flds.FldName(flds.routeId), false, false, "")
 	agencyId := getString(flds.agencyId, r, flds.FldName(flds.agencyId), false, false, "")
@@ -804,13 +804,13 @@ func createAgency(r []string, flds AgencyFields, feed *Feed, prefix string) (ag 
 	a := new(gtfs.Agency)
 
 	a.Id = prefix + getString(flds.agencyId, r, flds.FldName(flds.agencyId), false, false, "")
-	a.Name = getString(flds.agencyName, r, flds.FldName(flds.agencyName), true, true, feed.opts.EmptyStringRepl)
-	a.Url = getURL(flds.agencyUrl, r, flds, false, feed.opts.UseDefValueOnError, feed)
-	a.Timezone = *getTimezone(flds.agencyTimezone, r, flds, true, feed.opts.UseDefValueOnError, feed)
-	a.Lang = getIsoLangCode(flds.agencyLang, r, flds.FldName(flds.agencyTimezone), false, feed.opts.UseDefValueOnError, feed)
+	a.Name = getString(flds.agencyName, r, flds.FldName(flds.agencyName), true, true, feed.Opts.EmptyStringRepl)
+	a.Url = getURL(flds.agencyUrl, r, flds, false, feed.Opts.UseDefValueOnError, feed)
+	a.Timezone = *getTimezone(flds.agencyTimezone, r, flds, true, feed.Opts.UseDefValueOnError, feed)
+	a.Lang = getIsoLangCode(flds.agencyLang, r, flds.FldName(flds.agencyTimezone), false, feed.Opts.UseDefValueOnError, feed)
 	a.Phone = getString(flds.agencyPhone, r, flds.FldName(flds.agencyPhone), false, false, "")
-	a.Fare_url = getURL(flds.agencyFareUrl, r, flds, false, feed.opts.UseDefValueOnError, feed)
-	a.Email = getMail(flds.agencyEmail, r, flds, false, feed.opts.UseDefValueOnError, feed)
+	a.Fare_url = getURL(flds.agencyFareUrl, r, flds, false, feed.Opts.UseDefValueOnError, feed)
+	a.Email = getMail(flds.agencyEmail, r, flds, false, feed.Opts.UseDefValueOnError, feed)
 
 	return a, nil
 }
@@ -823,14 +823,14 @@ func createFeedInfo(r []string, flds FeedInfoFields, feed *Feed) (fi *gtfs.FeedI
 	}()
 	f := new(gtfs.FeedInfo)
 
-	f.Publisher_name = getString(flds.feedPublisherName, r, flds.FldName(flds.feedPublisherName), true, true, feed.opts.EmptyStringRepl)
-	f.Publisher_url = getURL(flds.feedPublisherUrl, r, flds, true, feed.opts.UseDefValueOnError, feed)
-	f.Lang = getString(flds.feedLang, r, flds.FldName(flds.feedLang), true, true, feed.opts.EmptyStringRepl)
-	f.Start_date = getDate(flds.feedStartDate, r, flds, false, feed.opts.UseDefValueOnError, feed)
-	f.End_date = getDate(flds.feedEndDate, r, flds, false, feed.opts.UseDefValueOnError, feed)
+	f.Publisher_name = getString(flds.feedPublisherName, r, flds.FldName(flds.feedPublisherName), true, true, feed.Opts.EmptyStringRepl)
+	f.Publisher_url = getURL(flds.feedPublisherUrl, r, flds, true, feed.Opts.UseDefValueOnError, feed)
+	f.Lang = getString(flds.feedLang, r, flds.FldName(flds.feedLang), true, true, feed.Opts.EmptyStringRepl)
+	f.Start_date = getDate(flds.feedStartDate, r, flds, false, feed.Opts.UseDefValueOnError, feed)
+	f.End_date = getDate(flds.feedEndDate, r, flds, false, feed.Opts.UseDefValueOnError, feed)
 	f.Version = getString(flds.feedVersion, r, flds.FldName(flds.feedVersion), false, false, "")
-	f.Contact_email = getMail(flds.feedContactEmail, r, flds, false, feed.opts.UseDefValueOnError, feed)
-	f.Contact_url = getURL(flds.feedContactUrl, r, flds, false, feed.opts.UseDefValueOnError, feed)
+	f.Contact_email = getMail(flds.feedContactEmail, r, flds, false, feed.Opts.UseDefValueOnError, feed)
+	f.Contact_url = getURL(flds.feedContactUrl, r, flds, false, feed.Opts.UseDefValueOnError, feed)
 
 	return f, nil
 }
@@ -852,7 +852,7 @@ func createFrequency(r []string, flds FrequencyFields, feed *Feed, prefix string
 		panic(&TripNotFoundErr{prefix, r[flds.tripId]})
 	}
 
-	a.Exact_times = getBool(flds.exactTimes, r, flds.FldName(flds.exactTimes), false, false, feed.opts.UseDefValueOnError, feed)
+	a.Exact_times = getBool(flds.exactTimes, r, flds.FldName(flds.exactTimes), false, false, feed.Opts.UseDefValueOnError, feed)
 	a.Start_time = getTime(flds.startTime, r, flds.FldName(flds.startTime))
 	a.End_time = getTime(flds.endTime, r, flds.FldName(flds.endTime))
 
@@ -862,7 +862,7 @@ func createFrequency(r []string, flds FrequencyFields, feed *Feed, prefix string
 
 	a.Headway_secs = getPositiveInt(flds.headwaySecs, r, flds.FldName(flds.headwaySecs), true)
 
-	if !feed.opts.DryRun {
+	if !feed.Opts.DryRun {
 		if trip.Frequencies == nil {
 			freqs := make([]*gtfs.Frequency, 0)
 			trip.Frequencies = &freqs
@@ -888,7 +888,7 @@ func createRoute(r []string, flds RouteFields, feed *Feed, prefix string) (route
 		if val, ok := feed.Agencies[aID]; ok {
 			a.Agency = val
 		} else {
-			if feed.opts.UseDefValueOnError {
+			if feed.Opts.UseDefValueOnError {
 				if len(feed.Agencies) == 1 {
 					for _, ag := range feed.Agencies {
 						a.Agency = ag
@@ -930,13 +930,13 @@ func createRoute(r []string, flds RouteFields, feed *Feed, prefix string) (route
 	a.Short_name = getString(flds.routeShortName, r, flds.FldName(flds.routeShortName), false, false, "")
 	a.Long_name = getString(flds.routeLongName, r, flds.FldName(flds.routeLongName), false, false, "")
 
-	if feed.opts.RemoveFillers {
+	if feed.Opts.RemoveFillers {
 		a.Short_name = removeFillers(a.Short_name)
 		a.Long_name = removeFillers(a.Long_name)
 	}
 
 	if len(a.Short_name) == 0 && len(a.Long_name) == 0 {
-		if feed.opts.UseDefValueOnError {
+		if feed.Opts.UseDefValueOnError {
 			a.Short_name = "-"
 		} else {
 			return nil, errors.New("either route_short_name or route_long_name are required")
@@ -949,18 +949,18 @@ func createRoute(r []string, flds RouteFields, feed *Feed, prefix string) (route
 
 	a.Desc = getString(flds.routeDesc, r, flds.FldName(flds.routeDesc), false, false, "")
 
-	if feed.opts.RemoveFillers {
+	if feed.Opts.RemoveFillers {
 		a.Desc = removeFillers(a.Desc)
 	}
 
 	a.Type = int16(getRangeInt(flds.routeType, r, flds.FldName(flds.routeType), true, 0, 1702)) // allow extended route types
 
-	a.Url = getURL(flds.routeUrl, r, flds, false, feed.opts.UseDefValueOnError, feed)
-	a.Color = getColor(flds.routeColor, r, flds.FldName(flds.routeColor), false, "ffffff", feed.opts.UseDefValueOnError, feed)
-	a.Text_color = getColor(flds.routeTextColor, r, flds.FldName(flds.routeTextColor), false, "000000", feed.opts.UseDefValueOnError, feed)
-	a.Sort_order = getPositiveIntWithDefault(flds.routeSortOrder, r, flds.FldName(flds.routeSortOrder), -1, feed.opts.UseDefValueOnError, feed)
-	a.Continuous_pickup = int8(getRangeIntWithDefault(flds.continuousPickup, r, flds.FldName(flds.routeSortOrder), 0, 3, 1, feed.opts.UseDefValueOnError, feed))
-	a.Continuous_drop_off = int8(getRangeIntWithDefault(flds.continuousDropOff, r, flds.FldName(flds.continuousDropOff), 0, 3, 1, feed.opts.UseDefValueOnError, feed))
+	a.Url = getURL(flds.routeUrl, r, flds, false, feed.Opts.UseDefValueOnError, feed)
+	a.Color = getColor(flds.routeColor, r, flds.FldName(flds.routeColor), false, "ffffff", feed.Opts.UseDefValueOnError, feed)
+	a.Text_color = getColor(flds.routeTextColor, r, flds.FldName(flds.routeTextColor), false, "000000", feed.Opts.UseDefValueOnError, feed)
+	a.Sort_order = getPositiveIntWithDefault(flds.routeSortOrder, r, flds.FldName(flds.routeSortOrder), -1, feed.Opts.UseDefValueOnError, feed)
+	a.Continuous_pickup = int8(getRangeIntWithDefault(flds.continuousPickup, r, flds.FldName(flds.routeSortOrder), 0, 3, 1, feed.Opts.UseDefValueOnError, feed))
+	a.Continuous_drop_off = int8(getRangeIntWithDefault(flds.continuousDropOff, r, flds.FldName(flds.continuousDropOff), 0, 3, 1, feed.Opts.UseDefValueOnError, feed))
 
 	return a, nil
 }
@@ -976,13 +976,13 @@ func createServiceFromCalendar(r []string, flds CalendarFields, feed *Feed, pref
 	service.SetId(prefix + getString(flds.serviceId, r, flds.FldName(flds.serviceId), true, true, ""))
 
 	// fill daybitmap
-	service.SetDaymap(1, getBool(flds.monday, r, flds.FldName(flds.monday), true, false, feed.opts.UseDefValueOnError, feed))
-	service.SetDaymap(2, getBool(flds.tuesday, r, flds.FldName(flds.tuesday), true, false, feed.opts.UseDefValueOnError, feed))
-	service.SetDaymap(3, getBool(flds.wednesday, r, flds.FldName(flds.wednesday), true, false, feed.opts.UseDefValueOnError, feed))
-	service.SetDaymap(4, getBool(flds.thursday, r, flds.FldName(flds.thursday), true, false, feed.opts.UseDefValueOnError, feed))
-	service.SetDaymap(5, getBool(flds.friday, r, flds.FldName(flds.friday), true, false, feed.opts.UseDefValueOnError, feed))
-	service.SetDaymap(6, getBool(flds.saturday, r, flds.FldName(flds.saturday), true, false, feed.opts.UseDefValueOnError, feed))
-	service.SetDaymap(0, getBool(flds.sunday, r, flds.FldName(flds.sunday), true, false, feed.opts.UseDefValueOnError, feed))
+	service.SetDaymap(1, getBool(flds.monday, r, flds.FldName(flds.monday), true, false, feed.Opts.UseDefValueOnError, feed))
+	service.SetDaymap(2, getBool(flds.tuesday, r, flds.FldName(flds.tuesday), true, false, feed.Opts.UseDefValueOnError, feed))
+	service.SetDaymap(3, getBool(flds.wednesday, r, flds.FldName(flds.wednesday), true, false, feed.Opts.UseDefValueOnError, feed))
+	service.SetDaymap(4, getBool(flds.thursday, r, flds.FldName(flds.thursday), true, false, feed.Opts.UseDefValueOnError, feed))
+	service.SetDaymap(5, getBool(flds.friday, r, flds.FldName(flds.friday), true, false, feed.Opts.UseDefValueOnError, feed))
+	service.SetDaymap(6, getBool(flds.saturday, r, flds.FldName(flds.saturday), true, false, feed.Opts.UseDefValueOnError, feed))
+	service.SetDaymap(0, getBool(flds.sunday, r, flds.FldName(flds.sunday), true, false, feed.Opts.UseDefValueOnError, feed))
 	service.SetStart_date(getDate(flds.startDate, r, flds, true, false, feed))
 	service.SetEnd_date(getDate(flds.endDate, r, flds, true, false, feed))
 
@@ -1043,11 +1043,11 @@ func createStop(r []string, flds StopFields, feed *Feed, prefix string) (s *gtfs
 
 	a.Id = prefix + getString(flds.stopId, r, flds.FldName(flds.stopId), true, true, "")
 	a.Code = getString(flds.stopCode, r, flds.FldName(flds.stopCode), false, false, "")
-	a.Location_type = int8(getRangeIntWithDefault(flds.locationType, r, flds.FldName(flds.locationType), 0, 4, 0, feed.opts.UseDefValueOnError, feed))
-	a.Name = getString(flds.stopName, r, flds.FldName(flds.stopName), a.Location_type < 3, a.Location_type < 3, feed.opts.EmptyStringRepl)
+	a.Location_type = int8(getRangeIntWithDefault(flds.locationType, r, flds.FldName(flds.locationType), 0, 4, 0, feed.Opts.UseDefValueOnError, feed))
+	a.Name = getString(flds.stopName, r, flds.FldName(flds.stopName), a.Location_type < 3, a.Location_type < 3, feed.Opts.EmptyStringRepl)
 	a.Desc = getString(flds.stopDesc, r, flds.FldName(flds.stopDesc), false, false, "")
 
-	if feed.opts.RemoveFillers {
+	if feed.Opts.RemoveFillers {
 		a.Desc = removeFillers(a.Desc)
 		a.Code = removeFillers(a.Code)
 	}
@@ -1056,15 +1056,15 @@ func createStop(r []string, flds StopFields, feed *Feed, prefix string) (s *gtfs
 		a.Lat = getFloat(flds.stopLat, r, flds.FldName(flds.stopLat), true)
 		a.Lon = getFloat(flds.stopLon, r, flds.FldName(flds.stopLon), true)
 	} else {
-		lat := getNullableFloat(flds.stopLat, r, flds.FldName(flds.stopLat), feed.opts.UseDefValueOnError, feed)
-		lon := getNullableFloat(flds.stopLon, r, flds.FldName(flds.stopLon), feed.opts.UseDefValueOnError, feed)
+		lat := getNullableFloat(flds.stopLat, r, flds.FldName(flds.stopLat), feed.Opts.UseDefValueOnError, feed)
+		lon := getNullableFloat(flds.stopLon, r, flds.FldName(flds.stopLon), feed.Opts.UseDefValueOnError, feed)
 
 		if !math.IsNaN(float64(lat)) && !math.IsNaN(float64(lon)) {
 			a.Lat = lat
 			a.Lon = lon
 		} else if !math.IsNaN(float64(lat)) {
 			locErr := fmt.Errorf("stop_lat and stop_lon are optional for location_type=%d, but only stop_lon was ommitted here, and stop_lat was defined", a.Location_type)
-			if feed.opts.UseDefValueOnError {
+			if feed.Opts.UseDefValueOnError {
 				feed.warn(locErr)
 				a.Lat = float32(math.NaN())
 				a.Lon = float32(math.NaN())
@@ -1073,7 +1073,7 @@ func createStop(r []string, flds StopFields, feed *Feed, prefix string) (s *gtfs
 			}
 		} else if !math.IsNaN(float64(lon)) {
 			locErr := fmt.Errorf("stop_lat and stop_lon are optional for location_type=%d, but only stop_lat was ommitted here, and stop_lon was defined", a.Location_type)
-			if feed.opts.UseDefValueOnError {
+			if feed.Opts.UseDefValueOnError {
 				feed.warn(locErr)
 				a.Lat = float32(math.NaN())
 				a.Lon = float32(math.NaN())
@@ -1096,7 +1096,7 @@ func createStop(r []string, flds StopFields, feed *Feed, prefix string) (s *gtfs
 	}
 
 	// check for 0,0 coordinates, which are most definitely an error
-	if a.HasLatLon() && feed.opts.CheckNullCoordinates && math.Abs(float64(a.Lat)) < 0.0001 && math.Abs(float64(a.Lon)) < 0.0001 {
+	if a.HasLatLon() && feed.Opts.CheckNullCoordinates && math.Abs(float64(a.Lat)) < 0.0001 && math.Abs(float64(a.Lon)) < 0.0001 {
 		panic(fmt.Errorf("expected coordinate (lat, lon), instead found (0, 0), which is in the middle of the atlantic"))
 	}
 
@@ -1104,7 +1104,7 @@ func createStop(r []string, flds StopFields, feed *Feed, prefix string) (s *gtfs
 	if len(a.Zone_id) == len(prefix) {
 		a.Zone_id = ""
 	}
-	a.Url = getURL(flds.stopUrl, r, flds, false, feed.opts.UseDefValueOnError, feed)
+	a.Url = getURL(flds.stopUrl, r, flds, false, feed.Opts.UseDefValueOnError, feed)
 
 	// will be filled later on
 	a.Parent_station = nil
@@ -1119,8 +1119,8 @@ func createStop(r []string, flds StopFields, feed *Feed, prefix string) (s *gtfs
 		}
 	}
 
-	a.Timezone = getTimezone(flds.stopTimezone, r, flds, false, feed.opts.UseDefValueOnError, feed)
-	a.Wheelchair_boarding = int8(getRangeIntWithDefault(flds.wheelchairBoarding, r, flds.FldName(flds.wheelchairBoarding), 0, 2, 0, feed.opts.UseDefValueOnError, feed))
+	a.Timezone = getTimezone(flds.stopTimezone, r, flds, false, feed.Opts.UseDefValueOnError, feed)
+	a.Wheelchair_boarding = int8(getRangeIntWithDefault(flds.wheelchairBoarding, r, flds.FldName(flds.wheelchairBoarding), 0, 2, 0, feed.Opts.UseDefValueOnError, feed))
 	a.Level = nil
 
 	levelId := prefix + getString(flds.levelId, r, flds.FldName(flds.levelId), false, false, "")
@@ -1182,7 +1182,7 @@ func createStopTime(r []string, flds *StopTimeFields, feed *Feed, prefix string)
 		panic(&TripNotFoundErr{prefix, getString(flds.tripId, r, flds.FldName(flds.tripId), true, true, "")})
 	}
 
-	if !feed.opts.DateFilterStart.IsEmpty() || !feed.opts.DateFilterEnd.IsEmpty() {
+	if !feed.Opts.DateFilterStart.IsEmpty() || !feed.Opts.DateFilterEnd.IsEmpty() {
 		// this trip will later be deleted - dont store stop times for it!
 		s := trip.Service
 		if (s.IsEmpty() && s.Start_date().IsEmpty() && s.End_date().IsEmpty()) || s.GetFirstActiveDate().IsEmpty() {
@@ -1213,7 +1213,7 @@ func createStopTime(r []string, flds *StopTimeFields, feed *Feed, prefix string)
 	a.SetDeparture_time(getTime(flds.departureTime, r, flds.FldName(flds.departureTime)))
 
 	if a.Arrival_time().Empty() && !a.Departure_time().Empty() {
-		if feed.opts.UseDefValueOnError {
+		if feed.Opts.UseDefValueOnError {
 			a.SetArrival_time(a.Departure_time())
 		} else {
 			panic(errors.New("Missing arrival time for " + getString(flds.stopId, r, flds.FldName(flds.stopId), true, true, "") + "."))
@@ -1221,7 +1221,7 @@ func createStopTime(r []string, flds *StopTimeFields, feed *Feed, prefix string)
 	}
 
 	if !a.Arrival_time().Empty() && a.Departure_time().Empty() {
-		if feed.opts.UseDefValueOnError {
+		if feed.Opts.UseDefValueOnError {
 			a.SetDeparture_time(a.Arrival_time())
 		} else {
 			panic(errors.New("Missing departure time for " + getString(flds.stopId, r, flds.FldName(flds.stopId), true, true, "") + "."))
@@ -1245,18 +1245,18 @@ func createStopTime(r []string, flds *StopTimeFields, feed *Feed, prefix string)
 
 	a.SetPickup_type(uint8(getRangeInt(flds.pickupType, r, flds.FldName(flds.pickupType), false, 0, 3)))
 	a.SetDrop_off_type(uint8(getRangeInt(flds.dropOffType, r, flds.FldName(flds.dropOffType), false, 0, 3)))
-	a.SetContinuous_pickup(uint8(getRangeIntWithDefault(flds.continuousPickup, r, flds.FldName(flds.continuousPickup), 0, 3, 1, feed.opts.UseDefValueOnError, feed)))
-	a.SetContinuous_drop_off(uint8(getRangeIntWithDefault(flds.continuousDropOff, r, flds.FldName(flds.continuousDropOff), 0, 3, 1, feed.opts.UseDefValueOnError, feed)))
-	dist := getNullableFloat(flds.shapeDistTraveled, r, flds.FldName(flds.shapeDistTraveled), feed.opts.UseDefValueOnError, feed)
+	a.SetContinuous_pickup(uint8(getRangeIntWithDefault(flds.continuousPickup, r, flds.FldName(flds.continuousPickup), 0, 3, 1, feed.Opts.UseDefValueOnError, feed)))
+	a.SetContinuous_drop_off(uint8(getRangeIntWithDefault(flds.continuousDropOff, r, flds.FldName(flds.continuousDropOff), 0, 3, 1, feed.Opts.UseDefValueOnError, feed)))
+	dist := getNullableFloat(flds.shapeDistTraveled, r, flds.FldName(flds.shapeDistTraveled), feed.Opts.UseDefValueOnError, feed)
 	a.SetShape_dist_traveled(dist)
-	a.SetTimepoint(getBool(flds.timepoint, r, flds.FldName(flds.timepoint), false, !a.Arrival_time().Empty() && !a.Departure_time().Empty(), feed.opts.UseDefValueOnError, feed))
+	a.SetTimepoint(getBool(flds.timepoint, r, flds.FldName(flds.timepoint), false, !a.Arrival_time().Empty() && !a.Departure_time().Empty(), feed.Opts.UseDefValueOnError, feed))
 
 	if (a.Arrival_time().Empty() || a.Departure_time().Empty()) && a.Timepoint() {
 		locErr := errors.New("stops with timepoint=1 cannot have empty arrival or departure time")
-		if feed.opts.UseDefValueOnError {
+		if feed.Opts.UseDefValueOnError {
 			a.SetTimepoint(false)
 			feed.warn(locErr)
-		} else if !feed.opts.DropErroneous {
+		} else if !feed.Opts.DropErroneous {
 			panic(locErr)
 		}
 		feed.warn(locErr)
@@ -1290,7 +1290,7 @@ func createTrip(r []string, flds TripFields, feed *Feed, prefix string) (t *gtfs
 
 	toDel := false
 
-	if !feed.opts.DateFilterStart.IsEmpty() || !feed.opts.DateFilterEnd.IsEmpty() {
+	if !feed.Opts.DateFilterStart.IsEmpty() || !feed.Opts.DateFilterEnd.IsEmpty() {
 		// this trip will later be deleted - dont store or parse additional fields (strings) for it
 		s := a.Service
 		if (s.IsEmpty() && s.Start_date().IsEmpty() && s.End_date().IsEmpty()) || s.GetFirstActiveDate().IsEmpty() {
@@ -1317,13 +1317,13 @@ func createTrip(r []string, flds TripFields, feed *Feed, prefix string) (t *gtfs
 	if len(shortName) > 0 {
 		a.Short_name = &shortName
 	}
-	a.Direction_id = int8(getRangeIntWithDefault(flds.directionId, r, flds.FldName(flds.directionId), 0, 1, -1, feed.opts.UseDefValueOnError, feed))
+	a.Direction_id = int8(getRangeIntWithDefault(flds.directionId, r, flds.FldName(flds.directionId), 0, 1, -1, feed.Opts.UseDefValueOnError, feed))
 	blockid := prefix + getString(flds.blockId, r, flds.FldName(flds.blockId), false, false, "")
 	if len(blockid) != len(prefix) {
 		a.Block_id = &blockid
 	}
 
-	if !feed.opts.DropShapes {
+	if !feed.Opts.DropShapes {
 		shapeID := prefix + getString(flds.shapeId, r, flds.FldName(flds.shapeId), false, false, "")
 
 		if len(shapeID) > len(prefix) {
@@ -1331,9 +1331,9 @@ func createTrip(r []string, flds TripFields, feed *Feed, prefix string) (t *gtfs
 				a.Shape = val
 			} else {
 				locErr := fmt.Errorf("no shape with id %s found", shapeID)
-				if len(feed.opts.PolygonFilter) > 0 {
+				if len(feed.Opts.PolygonFilter) > 0 {
 					a.Shape = nil
-				} else if feed.opts.UseDefValueOnError {
+				} else if feed.Opts.UseDefValueOnError {
 					feed.warn(locErr)
 					a.Shape = nil
 				} else {
@@ -1343,8 +1343,8 @@ func createTrip(r []string, flds TripFields, feed *Feed, prefix string) (t *gtfs
 		}
 	}
 
-	a.Wheelchair_accessible = int8(getRangeIntWithDefault(flds.wheelchairAccessible, r, flds.FldName(flds.wheelchairAccessible), 0, 2, 0, feed.opts.UseDefValueOnError, feed))
-	a.Bikes_allowed = int8(getRangeIntWithDefault(flds.bikesAllowed, r, flds.FldName(flds.bikesAllowed), 0, 2, 0, feed.opts.UseDefValueOnError, feed))
+	a.Wheelchair_accessible = int8(getRangeIntWithDefault(flds.wheelchairAccessible, r, flds.FldName(flds.wheelchairAccessible), 0, 2, 0, feed.Opts.UseDefValueOnError, feed))
+	a.Bikes_allowed = int8(getRangeIntWithDefault(flds.bikesAllowed, r, flds.FldName(flds.bikesAllowed), 0, 2, 0, feed.Opts.UseDefValueOnError, feed))
 
 	return a, nil
 }
@@ -1364,7 +1364,7 @@ func reserveShapePoint(r []string, flds ShapeFields, feed *Feed, prefix string) 
 
 	// check if any defined PolygonFilter contains the shape point
 	contains := true
-	for _, poly := range feed.opts.PolygonFilter {
+	for _, poly := range feed.Opts.PolygonFilter {
 		contains = false
 		if poly.PolyContains(float64(lon), float64(lat)) {
 			contains = true
@@ -1415,7 +1415,7 @@ func createShapePoint(r []string, flds ShapeFields, feed *Feed, prefix string) (
 		shape.Points = make(gtfs.ShapePoints, 0, shape.Points[0].Sequence)
 	}
 
-	dist := getNullableFloat(flds.shapeDistTraveled, r, flds.FldName(flds.shapeDistTraveled), feed.opts.UseDefValueOnError, feed)
+	dist := getNullableFloat(flds.shapeDistTraveled, r, flds.FldName(flds.shapeDistTraveled), feed.Opts.UseDefValueOnError, feed)
 
 	lat := getFloat(flds.shapePtLat, r, flds.FldName(flds.shapePtLat), true)
 	lon := getFloat(flds.shapePtLon, r, flds.FldName(flds.shapePtLon), true)
@@ -1430,13 +1430,13 @@ func createShapePoint(r []string, flds ShapeFields, feed *Feed, prefix string) (
 	}
 
 	// check for 0,0 coordinates, which are most definitely an error
-	if feed.opts.CheckNullCoordinates && math.Abs(float64(lat)) < 0.0001 && math.Abs(float64(lon)) < 0.0001 {
+	if feed.Opts.CheckNullCoordinates && math.Abs(float64(lat)) < 0.0001 && math.Abs(float64(lon)) < 0.0001 {
 		panic(fmt.Errorf("expected coordinate (lat, lon), instead found (0, 0), which is in the middle of the atlantic"))
 	}
 
 	// check if any defined PolygonFilter contains the shape point
 	contains := true
-	for _, poly := range feed.opts.PolygonFilter {
+	for _, poly := range feed.Opts.PolygonFilter {
 		contains = false
 		if poly.PolyContains(float64(lon), float64(lat)) {
 			contains = true
@@ -1471,13 +1471,13 @@ func createFareAttribute(r []string, flds FareAttributeFields, feed *Feed, prefi
 
 	a.Id = prefix + getString(flds.fareId, r, flds.FldName(flds.fareId), true, true, "")
 	a.Price = getString(flds.price, r, flds.FldName(flds.price), false, false, "")
-	if feed.opts.UseDefValueOnError {
+	if feed.Opts.UseDefValueOnError {
 		a.Currency_type = getString(flds.currencyType, r, flds.FldName(flds.currencyType), true, true, "XXX")
 	} else {
 		a.Currency_type = getString(flds.currencyType, r, flds.FldName(flds.currencyType), true, true, "")
 	}
 	a.Payment_method = getRangeInt(flds.paymentMethod, r, flds.FldName(flds.paymentMethod), false, 0, 1)
-	a.Transfers = getRangeIntWithDefault(flds.transfers, r, flds.FldName(flds.transfers), 0, 2, -1, feed.opts.UseDefValueOnError, feed)
+	a.Transfers = getRangeIntWithDefault(flds.transfers, r, flds.FldName(flds.transfers), 0, 2, -1, feed.Opts.UseDefValueOnError, feed)
 	a.Transfer_duration = getPositiveInt(flds.transferDuration, r, flds.FldName(flds.transferDuration), false)
 
 	aID := prefix + getString(flds.agencyId, r, flds.FldName(flds.agencyId), false, false, "")
@@ -1486,7 +1486,7 @@ func createFareAttribute(r []string, flds FareAttributeFields, feed *Feed, prefi
 		if val, ok := feed.Agencies[aID]; ok {
 			a.Agency = val
 		} else {
-			if feed.opts.UseDefValueOnError {
+			if feed.Opts.UseDefValueOnError {
 				a.Agency = nil
 			} else {
 				return nil, errors.New("No agency with id " + getString(flds.agencyId, r, flds.FldName(flds.agencyId), false, false, "") + " found.")
@@ -1631,7 +1631,7 @@ func createTransfer(r []string, flds TransferFields, feed *Feed, prefix string) 
 	}
 
 	tv.Transfer_type = getRangeInt(flds.TransferType, r, flds.FldName(flds.TransferType), false, 0, 5)
-	tv.Min_transfer_time = getPositiveIntWithDefault(flds.MinTransferTime, r, flds.FldName(flds.MinTransferTime), -1, feed.opts.UseDefValueOnError, feed)
+	tv.Min_transfer_time = getPositiveIntWithDefault(flds.MinTransferTime, r, flds.FldName(flds.MinTransferTime), -1, feed.Opts.UseDefValueOnError, feed)
 
 	return tk, tv, nil
 }
@@ -1666,20 +1666,20 @@ func createPathway(r []string, flds PathwayFields, feed *Feed, prefix string) (t
 	}
 
 	a.Mode = uint8(getRangeInt(flds.pathwayMode, r, flds.FldName(flds.pathwayMode), true, 1, 7))
-	a.Is_bidirectional = getBool(flds.isBidirectional, r, flds.FldName(flds.isBidirectional), true, false, feed.opts.UseDefValueOnError, feed)
+	a.Is_bidirectional = getBool(flds.isBidirectional, r, flds.FldName(flds.isBidirectional), true, false, feed.Opts.UseDefValueOnError, feed)
 
-	length := getNullableFloat(flds.length, r, flds.FldName(flds.length), feed.opts.UseDefValueOnError, feed)
+	length := getNullableFloat(flds.length, r, flds.FldName(flds.length), feed.Opts.UseDefValueOnError, feed)
 	a.Length = length
 
-	a.Traversal_time = int(getPositiveIntWithDefault(flds.traversalTime, r, flds.FldName(flds.traversalTime), -1, feed.opts.UseDefValueOnError, feed))
+	a.Traversal_time = int(getPositiveIntWithDefault(flds.traversalTime, r, flds.FldName(flds.traversalTime), -1, feed.Opts.UseDefValueOnError, feed))
 
-	a.Stair_count = getIntWithDefault(flds.stairCount, r, flds.FldName(flds.stairCount), 0, feed.opts.UseDefValueOnError, feed)
-	a.Max_slope = getNullableFloat(flds.maxSlope, r, flds.FldName(flds.maxSlope), feed.opts.UseDefValueOnError, feed)
+	a.Stair_count = getIntWithDefault(flds.stairCount, r, flds.FldName(flds.stairCount), 0, feed.Opts.UseDefValueOnError, feed)
+	a.Max_slope = getNullableFloat(flds.maxSlope, r, flds.FldName(flds.maxSlope), feed.Opts.UseDefValueOnError, feed)
 	if math.IsNaN(float64(a.Max_slope)) {
 		a.Max_slope = 0
 	}
 
-	width := getNullablePositiveFloat(flds.minWidth, r, flds, feed.opts.UseDefValueOnError, feed)
+	width := getNullablePositiveFloat(flds.minWidth, r, flds, feed.Opts.UseDefValueOnError, feed)
 	a.Min_width = width
 
 	a.Signposted_as = getString(flds.signpostedAs, r, flds.FldName(flds.signpostedAs), false, false, "")
@@ -1698,7 +1698,7 @@ func createLevel(r []string, flds LevelFields, feed *Feed, idprefix string) (t *
 	a := new(gtfs.Level)
 
 	a.Id = idprefix + getString(flds.levelId, r, flds.FldName(flds.levelId), true, true, "")
-	a.Index = getNullableFloat(flds.levelIndex, r, flds.FldName(flds.levelIndex), feed.opts.UseDefValueOnError, feed)
+	a.Index = getNullableFloat(flds.levelIndex, r, flds.FldName(flds.levelIndex), feed.Opts.UseDefValueOnError, feed)
 	if math.IsNaN(float64(a.Index)) {
 		a.Index = 0
 	}

--- a/parseerror.go
+++ b/parseerror.go
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a GPL v2
 // license that can be found in the LICENSE file
 
-package gtfsparser
+package gtfsparserwr
 
 import (
 	"fmt"


### PR DESCRIPTION
Added the possibility parse from an io.Reader instead of a local path. This is useful when you have to deal with remote references and/or login steps. Instead of having to create a temporary file on hdd and deleting it, now you can pass your ZIP io.Reader to ParseReader and it will handle everything it needs.

Also added an option to skip stop time validation in case of malformed GTFS (had a few issues with a local provider).